### PR TITLE
add argument to specify axis for angular momentum jacobian

### DIFF
--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -383,6 +383,7 @@
 	  (inertia-matrix
 	   (make-matrix axis-dim (send self :calc-target-joint-dimension link-list)))
 	  (update-mass-properties t)
+          (axis-for-angular)
           ;; buffers for calculation
 	  (tmp-v0 (instantiate float-vector 0))
 	  (tmp-v1 (instantiate float-vector 1))
@@ -407,7 +408,7 @@
 	  (send* (elt link-list l) :calc-inertia-matrix-column column :inertia-matrix inertia-matrix
                  ;; axis-for-angular is the axis for calculation of angular variables
                  ;; for example, we calculate angular momentum around the whole-body Center Of Mass as follows.
-		 :axis-for-angular (send self :centroid nil)
+		 :axis-for-angular (if axis-for-angular axis-for-angular (send self :centroid nil))
 		 :translation-axis translation-axis :rotation-axis rotation-axis args)))
     inertia-matrix)
   ;; return   ;; COG jacobian [m]


### PR DESCRIPTION
Add argument to specify axis for angular momentum jacobian.
Calculate COG around angular momentum by default.
I did not use default argument such as 

```
    (axis-for-angular (send self :centroid nil))
```

because COG position will be calculated later (within this method). 
