### PR TITLE
Add :make-joint-min-max-table method

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -26,6 +26,7 @@
 
 (require :irtgeo)
 (require :irtutil)
+(require :pqp)
 
 (defclass joint
   :super propertied-object
@@ -77,25 +78,34 @@
   (:joint-min-max-table (&optional mm-table) (if mm-table (setq joint-min-max-table mm-table) joint-min-max-table))
   (:joint-min-max-target (&optional mm-target) (if mm-target (setq joint-min-max-target mm-target) joint-min-max-target))
   (:joint-min-max-table-angle-interpolate
-   (target-angle car-or-cadr)
-   (let* ((int-target-angle (floor target-angle)) ;; integer value convered as a hash tablle key
+   (target-angle min-or-max)
+   (let* ((int-target-angle (floor target-angle)) ;; integer value convered as a matrix table key
           (target-range (list int-target-angle (1+ int-target-angle))) ;; range of target-joint's angle, e.g., (car target-range) <= target-ang <= (cadr target-range)
-          (joint-range (mapcar #'(lambda (x) (funcall car-or-cadr (gethash x joint-min-max-table)))
+          (joint-range (mapcar #'(lambda (x)
+                                   (aref
+                                    joint-min-max-table
+                                    (case min-or-max
+                                          (:min-angle 1)
+                                          (:max-angle 2)
+                                          (t ))
+                                    (round
+                                     (-
+                                      (min (max (aref joint-min-max-table 0 0) x)
+                                           (aref joint-min-max-table 0 (- (array-dimension joint-min-max-table 1) 1)))
+                                      (aref joint-min-max-table 0 0)))
+                                    ))
                                target-range)) ;; range of joint-angle based on target-range
           (tmp-ratio (- target-angle (float int-target-angle))))
-     ;; overrange check
-     (unless (elt joint-range 0) (setf (elt joint-range 0) (elt joint-range 1)))
-     (unless (elt joint-range 1) (setf (elt joint-range 1) (elt joint-range 0)))
      ;; calc min max
      ;; interpolated joint-angle based on joint-range
      ;; e.g., (car joint-range) <= min[max]-angle <= (cadr joint-range) or (cadr joint-range) <= min[max]-angle <= (car joint-range) 
      (+ (* (car joint-range) (- 1 tmp-ratio)) (* (cadr joint-range) tmp-ratio))))
   (:joint-min-max-table-min-angle
    (&optional (target-angle (send joint-min-max-target :joint-angle)))
-   (send self :joint-min-max-table-angle-interpolate target-angle #'car))
+   (send self :joint-min-max-table-angle-interpolate target-angle :min-angle))
   (:joint-min-max-table-max-angle
    (&optional (target-angle (send joint-min-max-target :joint-angle)))
-   (send self :joint-min-max-table-angle-interpolate target-angle #'cdr))
+   (send self :joint-min-max-table-angle-interpolate target-angle :max-angle))
   )
 
 (defun calc-jacobian-default-rotate-vector
@@ -809,6 +819,112 @@
        (setq ret1 (nconc (nreverse ret2) ret1))
        )
      ret1))
+  ;; for min-max table
+  (:make-joint-min-max-table
+   (l0 l1 joint0 joint1
+    ;; l0, l1         : link pair to be checked
+    ;; joint0, joint1 : joint to be check min and max angle
+    &key (fat 0) (fat2 nil) (debug nil)
+         (margin 0.0) ;; margin [deg] is margin angle from collision-based min-angle and max-angle
+         (overwrite-collision-model nil))
+   ;; initialize for :make-joint-min-max-table
+   (if (null debug) (send-all (send self :links) :analysis-level :coords))
+   (let* ((pc (send self :copy-worldcoords))
+          (pav (send self :angle-vector))
+          (min-joint0 (truncate (- (send joint0 :min-angle) 1e-4)))
+          (max-joint0 (truncate (+ (send joint0 :max-angle) 1e-4)))
+          (min-joint1 (truncate (- (send joint1 :min-angle) 1e-4)))
+          (max-joint1 (truncate (+ (send joint1 :max-angle) 1e-4)))
+          (joint-range0 (1+ (round (- max-joint0 min-joint0))))
+          (joint-range1 (1+ (round (- max-joint1 min-joint1)))))
+     (when debug
+       (format t ";~10A ~20,10f ~20,10f~%" (send joint0 :name) (send joint0 :min-angle) (send joint0 :max-angle))
+       (format t ";~10A ~20,10f ~20,10f~%" (send joint1 :name) (send joint1 :min-angle) (send joint1 :max-angle))
+       (format t ";~10A ~20,10f ~20,10f~%" (send joint0 :name) min-joint0 max-joint0)
+       (format t ";~10A ~20,10f ~20,10f~%" (send joint1 :name) min-joint1 max-joint1))
+     (send self :newcoords (make-coords))
+     (send self :init-pose)
+     (when overwrite-collision-model
+       (setf (get l0 :pqpmodel) nil)    
+       (setf (get l1 :pqpmodel) nil)
+       (pqp-collision-check l0 l1 geo::PQP_FIRST_CONTACT :fat fat :fat2 fat2))
+
+     (send self :make-min-max-table-using-collision-check
+           l0 l1 joint0 joint1 joint-range0 joint-range1 min-joint0 min-joint1 fat fat2 debug margin)
+
+     ;; finalize for :make-joint-min-max-table
+     (send self :angle-vector pav)
+     (send self :newcoords pc)
+     (if (null debug) (send-all (send self :links) :analysis-level :body))
+     nil
+     ))
+  (:make-min-max-table-using-collision-check
+   (l0 l1 joint0 joint1 joint-range0 joint-range1 min-joint0 min-joint1 fat fat2 debug margin)
+   ;; put collision check results into collision matrix "col-mat".
+   (let ((col-mat (make-matrix joint-range1 joint-range0)))
+          ;; col-mat : joint-range1 x joint-range0 matrix
+          ;;   collision-free region => 0
+          ;;   collision region => 1
+     (let (flag c (skip-count 10))
+       (do ((j 0 (+ j 1))) ((>= j joint-range1))
+           (send joint1 :joint-angle (round (+ j min-joint1)))
+           (setq flag :low-limit)
+           (when (= (mod j 10) 0)
+             (format t ";~c~7d/~7d" #x0d (* j joint-range0) (* joint-range0 joint-range1)) 
+             (finish-output))
+           (do ((i 0 (+ i 1))) ((>= i joint-range0))
+               (catch :min-max-collision-check
+                 (send joint0 :joint-angle (round (+ i min-joint0)))
+                 (cond
+                  ((and (eq flag :free) (/= (mod i skip-count) 0) (<= i (- joint-range0 skip-count)))
+                   (setq c t))
+                  (t
+                   (setq c (= (pqp-collision-check l0 l1 geo::PQP_FIRST_CONTACT :fat fat :fat2 fat2) 0))
+                   (cond 
+                    ((and (eq flag :low-limit) c) 
+                     (setq flag :free))
+                    ((and (eq flag :free) (not c))
+                     (setq flag :high-limit) (setq i (max (- i skip-count) 0))
+                     (throw :min-max-collision-check nil))
+                    )))
+                 (setf (aref col-mat j i) (if c 1 0))
+                 (if debug (format t ";~10A ~7,3f / ~10A ~7,3f / ~A ~A~%"
+                                   (send joint1 :name) (+ j min-joint1)
+                                   (send joint0 :name) (+ i min-joint0) c flag))
+                 ))))
+     (format t "~%")
+     ;; generate min-max table from collision matrix
+     (labels
+         ((gen-min-max-table-from-collision-matrix
+           (self-joint-range target-joint-range
+                             self-min-joint target-min-joint
+                             aref-func)
+           (let ((table (make-matrix 3 self-joint-range))) ;; row = self-joint-angle, target-min, target-max
+             (dotimes (i self-joint-range)
+               (let ((min-v (1+ self-joint-range)) (max-v 0) (flag nil))
+                 (dotimes (j target-joint-range)
+                   (when (= (funcall aref-func col-mat i j) 1)
+                     (setq flag t)
+                     (if (< j min-v)(setq min-v j)) (if (> j max-v)(setq max-v j))))
+                 (if (null flag) (setq min-v (- target-min-joint) max-v (- target-min-joint)))
+                 (setf (aref table 0 i) (round (+ self-min-joint i)))
+                 (setf (aref table 1 i) (round (+ margin target-min-joint min-v)))
+                 (setf (aref table 2 i) (round (+ (- margin) target-min-joint max-v)))
+                 ))
+             table)))
+       (let ((table0 (gen-min-max-table-from-collision-matrix
+                      joint-range0 joint-range1
+                      min-joint0 min-joint1
+                      #'(lambda (m i j) (aref m j i)))))
+         (send joint1 :joint-min-max-target joint0)
+         (send joint1 :joint-min-max-table table0))
+       (let ((table1 (gen-min-max-table-from-collision-matrix
+                      joint-range1 joint-range0
+                      min-joint1 min-joint0
+                      #'(lambda (m i j) (aref m i j)))))
+         (send joint0 :joint-min-max-target joint1)
+         (send joint0 :joint-min-max-table table1))
+       )))
   )
 
 ;;;

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -5,12 +5,12 @@
 (init-unit-test)
 
 (defclass 2dof-robot
-  :super cascaded-link
+  :super robot-model
   :slots (end-coords l1 l2 l3 j1 j2))
 (defmethod 2dof-robot
   (:init ()
          (send-super :init)
-         (setq l3 (send self :make-link (make-cube 40 40 80) #f(0 0 40) :read :l3))
+         (setq l3 (send self :make-link (make-cube 40 40 80) #f(0 0 40) :read 'l3))
          (setq end-coords (make-cascoords :pos #f(0 0 80)))
          (send l3 :assoc end-coords)
          (send l3 :locate #f(0 0 10))
@@ -19,7 +19,7 @@
          (send l2 :assoc l3)
          (send l2 :locate #f(0 0 80))
          ;;
-         (setq l1 (send self :make-link (body+ (make-cube 40 40 80 :pos #f(0 0 40))
+         (setq l1 (send self :make-link (body+ (make-cube 30 20 80 :pos #f(0 0 40))
                                                (make-cube 300 300 2)) #f(0 0 0) :white 'l1))
          (send l1 :assoc l2)
          (setq j1 (instance rotational-joint :init :parent-link l1 :child-link l2 :axis :z
@@ -96,8 +96,8 @@
 (deftest test-min-max-table
   (let* ((j1 (send *robot* :j1))
          (j2 (send *robot* :j2))
-         (j1-min-max-table (make-hash-table))
-         (j2-min-max-table (make-hash-table))
+         (j1-min-max-table (make-matrix 3 (round (+ 1 (- (send j1 :max-angle) (send j1 :min-angle))))))
+         (j2-min-max-table (make-matrix 3 (round (+ 1 (- (send j2 :max-angle) (send j2 :min-angle))))))
          (j1-org-min-angle (send j1 :min-angle)) (j2-org-min-angle (send j2 :min-angle))
          (j1-org-max-angle (send j1 :max-angle)) (j2-org-max-angle (send j2 :max-angle))
          min-max-table-view
@@ -107,7 +107,9 @@
     ;; j1-hash
     (mapcar #'(lambda (self-joint target-joint j-min-max-table)
                 (do ((i (round (send target-joint :min-angle)) (+ i 1))) ((> i (round (send target-joint :max-angle))))
-                  (setf (gethash (round i) j-min-max-table) (cons (- (abs i) (abs (send self-joint :min-angle))) (- (send self-joint :max-angle) (abs i)))))
+                    (setf (aref j-min-max-table 0 (round (- i (send self-joint :min-angle)))) i)
+                    (setf (aref j-min-max-table 1 (round (- i (send self-joint :min-angle)))) (- (abs i) (send self-joint :max-angle)))
+                    (setf (aref j-min-max-table 2 (round (- i (send self-joint :min-angle)))) (- (send self-joint :max-angle) (abs i))))
                 (send self-joint :joint-min-max-table j-min-max-table)
                 (send self-joint :joint-min-max-target target-joint))
             (list j1 j2)
@@ -126,8 +128,8 @@
           ((> x j1-org-max-angle))
         (do ((y j2-org-min-angle (+ y 1)))
             ((> y j2-org-max-angle))
-          (let* ((j1-min-max (gethash (round y) j1-min-max-table)) ;; j1-min-max-table is functoin of j2
-                 (j2-min-max (gethash (round x) j2-min-max-table))
+          (let* ((j1-min-max (cons (aref j1-min-max-table 1 (round (- y (aref j1-min-max-table 0 0)))) (aref j1-min-max-table 2 (round (- y (aref j1-min-max-table 0 0)))))) ;; j1-min-max-table is functoin of j2
+                 (j2-min-max (cons (aref j2-min-max-table 1 (round (- x (aref j2-min-max-table 0 0)))) (aref j2-min-max-table 2 (round (- x (aref j2-min-max-table 0 0))))))
                  (j1-min (car j1-min-max))
                  (j1-max (cdr j1-min-max))
                  (j2-min (car j2-min-max))
@@ -184,11 +186,114 @@
       )
     ;;
     ;; restore
-    (setq (j1 . joint-min-max-table) nil)
-    (setq (j1 . joint-min-max-target) nil)
-    (setq (j2 . joint-min-max-table) nil)
-    (setq (j2 . joint-min-max-target) nil)
+    (mapcar #'(lambda (j)
+                (setq (j . joint-min-max-table) nil)
+                (setq (j . joint-min-max-target) nil))
+            (send *robot* :joint-list))
     ))
+
+(defun plot-joint-min-max-table
+  (robot joint0 joint1)
+  (let ((min-max-table-view
+         (instance x::panel :create
+                   :width  (round (- (send joint0 :get :org-max-angle) (send joint0 :get :org-min-angle)))
+                   :height (round (- (send joint1 :get :org-max-angle) (send joint1 :get :org-min-angle)))
+                   :atitle "min-max-table-view")))
+    (send min-max-table-view :color #xffffff)
+    (send min-max-table-view :flush)
+    (null-output
+     (do ((j0 (get joint0 :org-min-angle) (+ 1 j0))) ((> j0 (get joint0 :org-max-angle)))
+         (send robot :init-pose)
+         (send joint0 :joint-angle j0)
+         (let ((flg0 (eps= (float (send joint0 :joint-angle)) (float j0))))
+           (do ((j1 (get joint1 :org-min-angle)(+ 1 j1))) ((> j1 (get joint1 :org-max-angle)))
+               (send joint1 :joint-angle j1)
+               (let ((flg1 (eps= (float (send joint1 :joint-angle)) (float j1))))
+                 (send min-max-table-view :color #xff0000)
+                 (if (and flg0 flg1)
+                     (send min-max-table-view :draw-line
+                           (float-vector (- (round j0) (get joint0 :org-min-angle)) (- (round j1) (get joint1 :org-min-angle)))
+                           (float-vector (- (round j0) (get joint0 :org-min-angle)) (- (round j1) (get joint1 :org-min-angle)))))
+                 ))
+           )))
+    (send min-max-table-view :flush)
+    ))
+
+(defun check-link-collision-for-joint-min-max-table
+  (robot link0 link1 joint0 joint1
+   &key (margin 0.0) ;; margin [deg] is margin angle from collision-based min-angle and max-angle
+        (debug-view nil))
+  (let ((col-ret) (non-col-ret))
+    (mapcar #'(lambda (self-joint target-joint)
+                (do ((self-ja (get self-joint :org-min-angle) (+ 1 self-ja))) ((> self-ja (get self-joint :org-max-angle)))
+                    (send robot :init-pose)
+                    (send self-joint :joint-angle self-ja)
+                    (mapcar #'(lambda (org-minmax minmax)
+                                ;; non-col-ret : No collision check
+                                ;;   If joint-min-max-table works and joint-angle is limited adequately, link0 and link1 do not collide each other.
+                                (null-output (send target-joint :joint-angle (get target-joint org-minmax)))
+                                (push (pqp-collision-check link0 link1) non-col-ret)
+                                (when (and debug-view (= (pqp-collision-check link0 link1) 1))
+                                  (objects (list link0 link1))
+                                  (let ((tmp (pqp-collision-distance link0 link1)))
+                                    (send (cadr tmp) :draw-on :flush nil :size 50)
+                                    (send (caddr tmp) :draw-on :flush t :size 50))
+                                  (read-line))
+                                ;; col-ret : Collision check
+                                ;;   If joint-min-max-table works and joint-angle is violated, link0 and link1 collide each other.
+                                (unless (eps= (float (send target-joint :joint-angle)) (get target-joint org-minmax))
+                                  (let ((org-table (send target-joint :joint-min-max-table)))
+                                    (setq (target-joint . joint-min-max-table) nil) ;; force violation by removing joint-min-max-table tempolarily
+                                    (send target-joint minmax (get target-joint org-minmax))
+                                    (let ((ja
+                                           (if (eq minmax :min-angle)
+                                               (+ -1 (- margin) (get target-joint org-minmax))
+                                             (+ 1 margin (get target-joint org-minmax)))))
+                                      (when (if (eq minmax :min-angle)
+                                                (> (+ -1 (- margin) (get target-joint org-minmax)) (get target-joint org-minmax))
+                                              (< (+ 1 margin (get target-joint org-minmax)) (get target-joint org-minmax)))
+                                        (null-output (send target-joint :joint-angle ja))
+                                        (push (pqp-collision-check link0 link1) col-ret)))
+                                    (send target-joint :joint-min-max-table org-table)
+                                    )))
+                            '(:org-min-angle :org-max-angle)
+                            '(:min-angle :max-angle))))
+            (list joint0 joint1)
+            (list joint1 joint0))
+    ;;(print non-col-ret)
+    ;;(print col-ret)
+    (list (every #'(lambda (x) (= x 0)) non-col-ret)
+          (every #'(lambda (x) (= x 1)) col-ret))
+    ))
+
+(defun test-make-joint-min-max-table-common
+  (&key (margin 0)) ;; [deg]
+  (dolist (j (send *robot* :joint-list))
+    (send j :put :org-max-angle (send j :max-angle))
+    (send j :put :org-min-angle (send j :min-angle)))
+  (send *robot* :self-collision-check)
+  (send *robot* :make-joint-min-max-table
+        (send (send *robot* :j1) :parent-link) (send (send *robot* :j2) :child-link) (send *robot* :j1) (send *robot* :j2)
+        :margin margin)
+  (unless (or (null x::*display*) (= x::*display* 0))
+    (plot-joint-min-max-table *robot* (send *robot* :j1) (send *robot* :j2))
+    ";; plot joint-min-max-table")
+  (prog1
+      (every #'identity (check-link-collision-for-joint-min-max-table
+                         *robot* (send (send *robot* :j1) :parent-link) (send (send *robot* :j2) :child-link) (send *robot* :j1) (send *robot* :j2)
+                         :margin margin))
+    ;; restore
+    (mapcar #'(lambda (j)
+                (setq (j . joint-min-max-table) nil)
+                (setq (j . joint-min-max-target) nil))
+            (send *robot* :joint-list))
+    ))
+
+(deftest test-make-joint-min-max-table-margin-0deg
+  (assert (test-make-joint-min-max-table-common :margin 0)))
+
+(deftest test-make-joint-min-max-table-margin-5deg
+  (assert (test-make-joint-min-max-table-common :margin 5)))
 
 (run-all-tests)
 (exit)


### PR DESCRIPTION
Add :make-joint-min-max-table method by copying and reducing codes from rbrain/basicmodel.l.
Add require of :pqp because irtmodel.l uses pqp resources.
