### PR TITLE
Find test codes in irteus/test directory to reduce description in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,7 @@ script: # All commands must exit with code 0 on success. Anything else is consid
   - cd jskeus
   - make
   - source bashrc.eus
-  - irteusgl irteus/test/irteus-demo.l
-  - irteusgl irteus/test/all-robots-objects.l
-  - irteusgl irteus/test/transparent.l
-  - irteusgl irteus/test/object.l
-  - irteusgl irteus/test/sort.l
-  - irteusgl irteus/test/bignum.l
-  - irteusgl irteus/test/vector.l
-  - irteusgl irteus/test/matrix.l
-  - irteusgl irteus/test/coords.l
-  - irteusgl irteus/test/read-img.l
-  - irteusgl irteus/test/graph.l
-  - irteusgl irteus/test/joint.l
-  - irteusgl irteus/test/test-irt-motion.l
+  - find irteus/test -iname "*.l" | grep -v unittest.l | xargs -n1 irteusgl
 after_failure:
   - echo "failure"
 


### PR DESCRIPTION
Find test codes in irteus/test directory to reduce description in .travis.yml according to the discussion[1]
Currently unittest.l is neglected. 
It does not work because of invalid exit code[2] or testing of intentional failure[3].

[1] https://github.com/euslisp/jskeus/commit/83432a3d75c950481e9f3079b077f47f73c1059dp
[2] euslisp/EusLisp#19
[3] jsk-ros-pkg/jsk_roseus#21 (comment)
