### PR TITLE
fix unsolved dual-arm-ik in irteus-demo.l by fix-leg-to-coords ;; replace deprecate fix-leg codes by :fix-leg-to-coords

### DIFF
--- a/irteus/demo/crank-motion.l
+++ b/irteus/demo/crank-motion.l
@@ -73,14 +73,8 @@
     (setq *robot* (instance sample-robot :init)))
   (send *robot* :reset-pose)
   (send *robot* :newcoords (make-coords))
-  (if (= (length (car (send *robot* :arms))) 6)
-      (send *robot* :arms :angle-vector #f(-20 20 0 -50 10 0 0)))
   (unless (some #'null (send *robot* :legs))
-    (mapcar #'(lambda (l)
-                (send *robot* l :inverse-kinematics
-                      (send (send *robot* l :end-coords :copy-worldcoords) :translate #f(0 0 30))))
-            '(:rleg :lleg))
-    (send *robot* :transform (send (apply #'midcoords 0.5 (send *robot* :legs :end-coords)) :transformation (make-coords))))
+    (send *robot* :fix-leg-to-coords (make-coords)))
   (send *robot* :update-descendants)
 
   (let ((crank (instance sample-crank :init)))

--- a/irteus/demo/dual-arm-ik.l
+++ b/irteus/demo/dual-arm-ik.l
@@ -66,11 +66,9 @@
     (unless (boundp '*robot*)
       (setq *robot* (instance sample-robot :init)))
     (send *robot* :reset-pose)
-    (if (= (length (car (send *robot* :arms))) 7)
-	(send *robot* :arms :angle-vector #f(10 20 0 -20 10 0 0)))
     (if (some #'null (send *robot* :legs))
 	(send *robot* :newcoords (make-coords))
-      (send *robot* :transform (send (apply #'midcoords 0.5 (send *robot* :legs :end-coords)) :transformation (make-coords))))
+      (send *robot* :fix-leg-to-coords (make-coords)))
     (send *robot* :update-descendants)
     ;;
     ;; make broom model

--- a/irteus/demo/dual-manip-ik.l
+++ b/irteus/demo/dual-manip-ik.l
@@ -7,12 +7,11 @@
   (send *irtviewer* :title "dual-manip-ik")
   (unless (boundp '*robot*)
     (setq *robot* (instance sample-robot :init)))
-  (send *robot* :newcoords (make-coords))
   (send *robot* :reset-pose)
   ;; fix leg
   (if (some #'null (send *robot* :legs))
       (send *robot* :newcoords (make-coords))
-    (send *robot* :transform (send (apply #'midcoords 0.5 (send *robot* :legs :end-coords)) :transformation (make-coords))))
+    (send *robot* :fix-leg-to-coords (make-coords)))
   (send *robot* :update-descendants)
   ;; generate object model
   (setq *obj* (make-cube 30 160 100))

--- a/irteus/demo/full-body-ik.l
+++ b/irteus/demo/full-body-ik.l
@@ -10,9 +10,9 @@
     (send *robot* :reset-pose)
     (if (= (length (car (send *robot* :legs))) 6)
 	(send *robot* :legs :angle-vector #f(0 0 -10 20 0 -10)))
-    (if (send *robot* :lleg)
-        (send *robot* :newcoords (send (make-coords) :transform (send (send *robot* :lleg :end-coords) :transformation *robot*))) ;fix-leg
-      (send *robot* :newcoords (make-coords)))
+    (if (some #'null (send *robot* :legs))
+	(send *robot* :newcoords (make-coords))
+      (send *robot* :fix-leg-to-coords (make-coords) :lleg))
     (send *robot* :update-descendants)
     (let* ((move-target (send *robot* :larm :end-coords))
            (link-list (send *robot* :link-list
@@ -38,9 +38,9 @@
                (if use-leg '(:manipulability-limit 0.5)))
        (send *robot* :head :look-at
              (send *robot* :larm :end-coords :worldpos))
-       (if (send *robot* :lleg)
-           (send *robot* :newcoords (send (make-coords) :transform (send (send *robot* :lleg :end-coords) :transformation *robot*))) ;fix-leg
-	 (send *robot* :newcoords (make-coords)))
+       (if (some #'null (send *robot* :legs))
+           (send *robot* :newcoords (make-coords))
+         (send *robot* :fix-leg-to-coords (make-coords) :lleg))
        (if use-leg (send *irtviewer* :draw-objects :flush nil))
        (send *irtviewer* :viewer :viewsurface :color #f(1 1 1))
        (send *irtviewer* :viewer :viewsurface :line-width 2)

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -7,7 +7,7 @@
           (< (abs (elt (send (send (car (send robot :links)) :transformation (apply #'midcoords 0.5 (send robot :legs :end-coords))) :worldpos) 2)) 400))
          (default-step-height (if is-small-robot 10 50)))
   (send robot :reset-pose)
-  (send robot :fix-leg-to-coords (make-coords) '(:rleg :lleg))
+  (send robot :fix-leg-to-coords (make-coords))
   (objects (list robot))
   (warn ";; test1 ;; specify footstep-list~%")
   (let* ((test1-scale (if is-small-robot 0.25 1.0))
@@ -48,7 +48,7 @@
          (default-step-height (if is-small-robot 10 50)))
   ;; At the initial posture, the COG is above the right foot.
   (send robot :reset-pose)
-  (send robot :fix-leg-to-coords (make-coords) '(:rleg :lleg))
+  (send robot :fix-leg-to-coords (make-coords))
   (send robot :move-centroid-on-foot :rleg '(:rleg :lleg))
   (objects (list robot))
   (warn ";; test1 ;; specify footstep-list~%")
@@ -90,7 +90,7 @@
     (setq *robot* (instance sample-robot :init)))
   ;; initial quad pose
   (send *robot* :reset-pose)
-  (send *robot* :fix-leg-to-coords (make-coords) '(:rleg :lleg))
+  (send *robot* :fix-leg-to-coords (make-coords))
   (send *robot* :rotate (if go-backward-over -pi/2 pi/2) :y)
   (let ((tc
          (if go-backward-over
@@ -260,7 +260,7 @@
     (objects (list robot))
     ;; generate input motion control ZMP at 0, which corresponds to COG at 0 in this case
     (send robot :reset-pose)
-    (send robot :fix-leg-to-coords (make-coords) '(:rleg :lleg))
+    (send robot :fix-leg-to-coords (make-coords))
     (dotimes (i 180)
       (send robot :arms :shoulder-p :joint-angle (+ -20 (* -45 (sin (* 6 (deg2rad i))))))
       (send robot :move-centroid-on-foot :both '(:lleg :rleg))


### PR DESCRIPTION
Fix unsolved dual-arm-ik in irteus-demo.l by fix-leg-to-coords. 
Replace deprecate fix-leg codes by :fix-leg-to-coords.
