### PR TITLE
modified kalman-filter

### DIFF
--- a/irteus/kalmanlib.l
+++ b/irteus/kalmanlib.l
@@ -49,6 +49,7 @@
   (:Q (&optional m) (if m (setq Q m) Q))
   (:R (&optional m) (if m (setq R m) R))
   (:x (&optional v) (if v (setq x_k v) x_k))
+  (:P (&optional m) (if m (setq P_k m) P_k))
   (:predict 
    () 
    (setq x_k-1 x_k)
@@ -60,6 +61,8 @@
    (z) ; measurement
    (setq z_k z)
    ;; S = HPH^ + R
+   (setq diff (matrix (v- z_k (transform H x_k))))
+   (setq R (m* (transpose diff) diff))
    (setq S (m+ (m* H (m* P_k (transpose H))) R))
    ;; K = P H^ S-1
    (setq K (m* (m* P_k (transpose H)) (inverse-matrix S)))
@@ -121,9 +124,9 @@
 
     (cond 
      ((or (eq arg 0) (eq arg 2))
-      (setq k (instance kalman-filter :init :state-dim 2)))
+      (setq k (instance kalman-filter :init :state-dim 2 :q-variance 2)))
      (t
-      (setq k (instance kalman-filter :init :state-dim 4 :r-variance 0.001))
+      (setq k (instance kalman-filter :init :state-dim 4 :q-variance 0.01))
       (send k :A #2f((1 0 1 0)(0 1 0 1)(0 0 1 0)(0 0 0 1)))))
 
     (with-open-file 


### PR DESCRIPTION
簡単のため共分散行列Rを固定していたと思われるが、Rを固定してしまうと、観測値と推定値のずれの情報が、推定誤差共分散行列P_kにいかなくなってしまう。
結果として、得られる推定誤差共分散行列は観測値を反映しないものとなってしまう。
（xyzの分散がすべて同じとなってしまう）

これを変更し、Rを共分散を直接計算するようにした。
この結果、xyzの分散が観測値を反映するようになった。
ただ、これにより発散しやすくなるので、発散してしまう時にはq-varianceの値を大きく変更してみたりすることが必要。
