### PR TITLE
add warning when the input of quaternion2matrix is not equal to 1

### DIFF
--- a/irteus/irtmath.l
+++ b/irteus/irtmath.l
@@ -138,6 +138,8 @@
 (defun quaternion2matrix (q)
   "returns matrix of given quaternion"
   (let ((q0 (elt q 0)) (q1 (elt q 1)) (q2 (elt q 2)) (q3 (elt q 3)))
+    (unless (eps= (v. q q) 1.0 0.01)
+        (warning-message 1 ";; quaternion2matrix : invalid input ~A, the norm is not 1~%" q))
     (make-matrix 
      3 3
      (list


### PR DESCRIPTION
``````
>> 一方で，quaternion2matrixでquaternionのノルムをみて１でなければなにかエラーかワーニングを出す，というのは有効かもしれません．どうでしょうかね\
> ？
> 賛成です。ノルムゼロなら単位行列を返してもいいかもしれません。
単位行列はちょっとやり過ぎな気がします．
既存のコードに影響がある可能性があるので，ワーニングくらいでいいのではないでしょうか.



-- ryohei



2014-11-16 23:11 GMT+09:00 Yohei Kakiuchi <youhei@jsk.imi.i.u-tokyo.ac.jp>:
> rosのメッセージは基本的に適切に初期化されないと考える必要があるということで、
> いかのような初期化になりそうです。
> (instance posedetection_msgs::Object6DPose :init :pose
> (ros::coords->tf-pose (make-coords)))
>
>> 一方で，quaternion2matrixでquaternionのノルムをみて１でなければなにかエラーかワーニングを出す，というのは有効かもしれません．どうでしょうかね\
> ？
> 賛成です。ノルムゼロなら単位行列を返してもいいかもしれません。
>
> 2014年11月16日 21:33 Kei Okada <k-okada@jsk.t.u-tokyo.ac.jp>:
>> これはどうしたらしいですかね．
>> ```
>>>>> from geometry_msgs.msg import Quaternion
>>>>> Quaternion()
>> x: 0.0
>> y: 0.0
>> z: 0.0
>> w: 0.0
>> ```
>> なのでこういうものかといえばそうかともおもいます．
>> 一方で，quaternion2matrixでquaternionのノルムをみて１でなければなにかエラーかワーニングを出す，というのは有効かもしれません．どうでしょうかね？
>>
>> 2014-11-14 14:20 GMT+09:00 kamada <h-kamada@jsk.imi.i.u-tokyo.ac.jp>:
>>>
>>> 変換ではまったのでメモしておきます。
>>> (send (send (ros::tf-pose->coords  (send (instance
>>> posedetection_msgs::Object6DPose :init) :pose)) :copy-worldcoords)
>>> :translate #f(10 10 10))
>>> を実行すると
>>> #<coordinates #X65c58e8  0.0 0.0 0.0 / 0.0 0.0 0.0>
>>> が返ってきます。
>>> 本来10 10 10が返ってきそうなので原因を調べてもらった結果、
>>>
>>> initした状態だとorientetionの中身４変数xyzwがすべて０になっていたために、それをcoordsに変換した際に何かしら問題が起きているためであるようです。
>>> wに１を代入して変換したところ、問題なく変換できました。
``````
