### PR TITLE
add document to irtgl.l

### DIFF
--- a/irteus/irtgl.l
+++ b/irteus/irtgl.l
@@ -499,7 +499,7 @@
   )
 
 (defmethod faceset
-  (:set-color    
+  (:set-color
    (color &optional (transparent))
    "Set color of given color name, color sample and color name are referenced from http://en.wikipedia.org/wiki/X11_color_names"
    (delete-displaylist-id (get self :GL-DISPLAYLIST-ID))


### PR DESCRIPTION
irtgl.lのset-colorの部分で
色見本についての記述を付け加えました。
また、set-colorで存在しない色の名前を渡された時ワーニングを出すようにしました。
