### PR TITLE
(irtviewer.l) : Resize viewport when irtviewer is resized.

### DIFF
--- a/irteus/irtviewer.l
+++ b/irteus/irtviewer.l
@@ -152,6 +152,10 @@
    (send viewer :viewsurface :resize newwidth newheight)
    (send viewer :viewsurface :makecurrent)
    (send viewer :viewsurface :3d-mode)
+   (let ((wh-max (max newwidth newheight)))
+     (send (send viewer :viewport)
+           :resize :width wh-max :height (- wh-max)
+           :xcenter (/ newwidth 2) :ycenter (/ newheight 2)))
    (send self :redraw))
   (:configureNotify
    (event)


### PR DESCRIPTION
Fix viewport resizing. 

Before this PR, `draw-line`, `draw-arrow`, and `draw-circle` methods do not work because viewport size is not changed.

```
(make-irtviewer)
;; work correctly
(send *irtviewer* :draw-objects)
(send *irtviewer* :viewer :draw-line #f(0 0 0) #f(100 100 100))
(send (make-coords) :draw-on :flush t)

;; does not  work correctly
(send *irtviewer* :resize 700 700)
(send *irtviewer* :draw-objects)
(send *irtviewer* :viewer :draw-line #f(0 0 0) #f(100 100 100))
(send (make-coords) :draw-on :flush t)
```

After this PR, above two examples work correctly.
