### PR TITLE
Move end-coords-list from robot-model slots to cascaded-link slots

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -727,7 +727,9 @@
 (defclass cascaded-link
   :super cascaded-coords
   :slots (links joint-list bodies
-		collision-avoidance-links))
+		collision-avoidance-links
+                end-coords-list
+                ))
 
 (defmethod cascaded-link
   (:init (&rest args
@@ -750,6 +752,10 @@
   (:joint-list (&rest args) "Returns joint list, or args is passed to joints" (user::forward-message-to-all joint-list args))
   (:link (name) "Return a link with given name." (find name links :test #'equal :key #'(lambda (x) (send x :name))))
   (:joint (name) "Return a joint with given name." (find name joint-list :test #'equal :key #'(lambda (x) (send x :name))))
+  (:end-coords
+   (name)
+   "Returns end-coords with given name"
+   (find name end-coords-list :test #'equal :key #'(lambda (x) (send x :name))))
 
   (:bodies (&rest args) "Return bodies of this object. If args is given it passed to all bodies" (user::forward-message-to-all bodies args))
   (:faces () "Return faces of this object." (flatten (send-all bodies :faces)))

--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -77,7 +77,6 @@
 	  larm-collision-avoidance-links
 	  rarm-collision-avoidance-links
 	  larm rarm lleg rleg torso head
-          end-coords-list
           ;; sensor slots
           force-sensors imu-sensors cameras
           ;;
@@ -255,11 +254,6 @@
   (:force-sensors () "Returns force sensors." force-sensors)
   (:imu-sensors () "Returns imu sensors." imu-sensors)
   (:cameras () "Returns camera sensors." cameras)
-  ;;
-  (:end-coords
-   (name)
-   "Returns end-coords with given name"
-   (find name end-coords-list :test #'equal :key #'(lambda (x) (send x :name))))
   ;;
   (:larm (&rest args) 
 	 (unless args (setq args (list nil))) (send* self :limb :larm args))


### PR DESCRIPTION
Move end-coords-list from robot-model slots to cascaded-link slot according to https://github.com/euslisp/jskeus/pull/183#issuecomment-85896553.