### PR TITLE
Remove unnecessary loop check

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -1941,7 +1941,7 @@
     (jacobi)
     (additional-check)
     (centroid-thre 1.0) (target-centroid-pos) (centroid-offset-func) (cog-translation-axis :z)
-    (min-loop)
+    (min-loop (/ stop 10))
     debug-view ik-args
     &allow-other-keys)
    ":inverse-kinematics-loop is one loop calculation for :inverse-kinematics.

--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -1948,6 +1948,7 @@
     ;;                  but ":additional-check" is neglected in the final :inverse-kinematics return.
     (additional-check)
     (centroid-thre 1.0) (target-centroid-pos) (centroid-offset-func) (cog-translation-axis :z)
+    (min-loop)
     debug-view ik-args
     &allow-other-keys)
    (if target-centroid-pos (send self :update-mass-properties))
@@ -2013,7 +2014,8 @@
        ;; convergence check
        (setq success
 	     (send self :ik-convergence-check
-		   (>= loop (/ stop 10)) dif-pos dif-rot
+		   (if min-loop (>= loop min-loop) t)
+                   dif-pos dif-rot
 		   rotation-axis translation-axis thre rthre
 		   centroid-thre target-centroid-pos centroid-offset-func cog-translation-axis
                    :update-mass-properties nil))

--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -1939,18 +1939,26 @@
     union-link-list
     target-coords                 ;required for debug-view
     (jacobi)
-    ;; :additional-check
-    ;;   This argument is to add optional best-effort convergence conditions.
-    ;;   ":additional-check" should be function or lambda.
-    ;;   best-effort => In :inverse-kinematics-loop, "success" is overwritten by "(and success additional-check)"
-    ;;                  In :inverse-kinematics, "success" is not overwritten.
-    ;;                  So, :inverse-kinematics-loop wait until ":additional-check" becomes "t" as possible,
-    ;;                  but ":additional-check" is neglected in the final :inverse-kinematics return.
     (additional-check)
     (centroid-thre 1.0) (target-centroid-pos) (centroid-offset-func) (cog-translation-axis :z)
     (min-loop)
     debug-view ik-args
     &allow-other-keys)
+   ":inverse-kinematics-loop is one loop calculation for :inverse-kinematics.
+    In this method, joint position difference satisfying workspace difference (dif-pos, dif-rot) are calculated and euslisp model joint angles are updated.
+    Optional arguments:
+     :additional-check
+       This argument is to add optional best-effort convergence conditions.
+       :additional-check should be function or lambda.
+       best-effort => In :inverse-kinematics-loop, 'success' is overwritten by '(and success additional-check)'
+                      In :inverse-kinematics, 'success is not overwritten.
+                      So, :inverse-kinematics-loop wait until ':additional-check' becomes 't' as possible,
+                      but ':additional-check' is neglected in the final :inverse-kinematics return.
+     :min-loop
+       Minimam loop count (nil by default).
+       If integer is specified, :inverse-kinematics-loop does returns :ik-continues and continueing solving IK.
+       If min-loop is nil, do not consider loop counting for IK convergence.
+    "
    (if target-centroid-pos (send self :update-mass-properties))
    ;; dif-pos, dif-rot, move-target, rotation-axis, translation-axis, link-list
    ;; -> both list and atom OK.


### PR DESCRIPTION
Remove unnecessary loop check according to https://github.com/euslisp/jskeus/issues/107 discussion.

- Problem  
Loop convergence waiting by `(>= loop (/ stop 10))` is unnecessary. Sometimes IK calculation becomes too slow (because of unnecessary waiting) and it is difficult to understand the code.
- Changes  
 Change `(>= loop (/ stop 10))` => `(>= loop min-loop)`
- Motivation of original code (`(>= loop (/ stop 10))`)  
 Practical way to wait for null-space motion. 
- Alternate method to wait for null-space motion  
 We can directly control null-space waiting by using `additional-check` and sample code is already added https://github.com/euslisp/jskeus/blob/master/irteus/demo/null-space-ik.l#L53
- Important notices  
 This commit will change some IK behavior.  
 If users do not change IK behavior, please specify `:min-loop` argument like this:  
 ```(send *robot* :inverse-kinematics xxxxx :min-loop (/ stop 10))```