### PR TITLE
Add concatenate matrix functions moved from euslib/jsk/jsk.l.

### DIFF
--- a/irteus/irtmath.l
+++ b/irteus/irtmath.l
@@ -468,6 +468,50 @@
     (elt (sort err #'<) (/ (length err) 2))
     ))
 
+(defun concatenate-matrix-column (&rest args)
+  "Concatenate matrix in column direction."
+  (let (m ml (size-of-column (array-dimension (car args) 1)))
+    (dolist (mat args)
+      (unless (= (array-dimension mat 1) size-of-column)
+        (error ";; concatenate-matrix-column matrix size error (size=~A)~%" (mapcar #'(lambda (x) (array-dimension x 1)) args)))
+      (setq m (if mat (length (matrix-column mat 0)) 0))
+      (dotimes (i m)
+        (push (matrix-row mat i) ml)))
+    (when ml (apply #'matrix (reverse ml)))
+    ))
+
+(defun concatenate-matrix-row (&rest args)
+  "Concatenate matrix in row direction."
+  (let (m ml (size-of-column (array-dimension (car args) 0)))
+    (dolist (mat args)
+      (unless (= (array-dimension mat 0) size-of-column)
+        (error ";; concatenate-matrix-row matrix size error (size=~A)~%" (mapcar #'(lambda (x) (array-dimension x 0)) args)))
+      (setq m (if mat (length (matrix-row mat 0)) 0))
+      (dotimes (i m)
+        (push (matrix-column mat i) ml)))
+    (when ml (transpose (apply #'matrix (reverse ml))))
+    ))
+
+(defun concatenate-matrix-diagonal (&rest args)
+  "Concatenate matrix in diagonal."
+  (let (mat m ll ml vl)
+    (dolist (mm args)
+      (push (if mm (length (matrix-row mm 0)) 0) ll))
+    (setq ll (reverse ll))
+    (dotimes (i (length args))
+      (setq mat (nth i args))
+      (setq m (if mat (length (matrix-column mat 0)) 0))
+      (dotimes (j m)
+        (setq vl nil)
+        (dotimes (k (length ll))
+          (if (= i k) (push (matrix-row mat j) vl)
+            (push (make-array (nth k ll)
+                              :element-type float-vector
+                              :initial-element 0) vl)))
+        (push (apply #'concatenate
+                     (cons float-vector (reverse vl))) ml)))
+    (when ml (apply #'matrix (reverse ml)))
+    ))
 
 #|
 (defun lms-draw (r point-list)

--- a/irteus/test/matrix.l
+++ b/irteus/test/matrix.l
@@ -39,5 +39,146 @@
         ))
     ))
 
+;;;;;;;;;;;;;;;;
+;; Test functions for matrix concatenation
+;;;;;;;;;;;;;;;;
+(defun make-random-matrix
+  (row-dim column-dim &key (random-range 1e10))
+  "Make matrix with given row dimension and column dimension.
+   Component of matrix is random value."
+  (make-matrix row-dim column-dim
+               (mapcar #'(lambda (row)
+                           (mapcar #'(lambda (column) (random random-range)) (make-list column-dim)))
+                       (make-list row-dim))))
+
+(defun make-random-matrix-list
+  (length
+   &key (same-row-p nil) (same-column-p nil)
+        (random-max-dim 100))
+  "Make matrix list with given length.
+   Component of matrix is random value and dimensions are random.
+   random-max-dim is max dimensions to be checked."
+  (let ((row-dim (if same-row-p (1+ (random random-max-dim))))
+        (col-dim (if same-column-p (1+ (random random-max-dim)))))
+    (mapcar
+     #'(lambda (x)
+         (make-random-matrix
+          (if same-row-p row-dim (1+ (random random-max-dim)))
+          (if same-column-p col-dim (1+ (random random-max-dim)))))
+     (make-list length))))
+
+;; Naive implementation of concatenate matrix for comparing values.
+(defun concatenate-matrix-column-naive-impl
+  (&rest args)
+  (if (> (length args) 2)
+      (concatenate-matrix-column-naive-impl
+       (car args)
+       (apply #'concatenate-matrix-column-naive-impl (cdr args)))
+    (let* ((mat0 (car args)) (mat1 (cadr args))
+           (mat0-row-dim (array-dimension mat0 0))
+           (mat1-row-dim (array-dimension mat1 0))
+           (col-dim (array-dimension mat0 1))
+           (con-mat1 (make-matrix (+ mat0-row-dim mat1-row-dim) col-dim)))
+      (dotimes (row-index0 mat0-row-dim)
+        (dotimes (column-index col-dim)
+          (setf (aref con-mat1 row-index0 column-index) (aref mat0 row-index0 column-index))))
+      (dotimes (row-index1 mat1-row-dim)
+        (dotimes (column-index col-dim)
+          (setf (aref con-mat1 (+ mat0-row-dim row-index1) column-index) (aref mat1 row-index1 column-index))))
+      con-mat1)))
+
+(defun concatenate-matrix-row-naive-impl
+  (&rest args)
+  (if (> (length args) 2)
+      (concatenate-matrix-row-naive-impl
+       (car args)
+       (apply #'concatenate-matrix-row-naive-impl (cdr args)))
+    (let* ((mat0 (car args)) (mat1 (cadr args))
+           (mat0-col-dim (array-dimension mat0 1))
+           (mat1-col-dim (array-dimension mat1 1))
+           (row-dim (array-dimension mat0 0))
+           (con-mat1 (make-matrix row-dim (+ mat0-col-dim mat1-col-dim))))
+      (dotimes (row-index row-dim)
+        (dotimes (column-index mat0-col-dim)
+          (setf (aref con-mat1 row-index column-index) (aref mat0 row-index column-index))))
+      (dotimes (row-index row-dim)
+        (dotimes (column-index mat1-col-dim)
+          (setf (aref con-mat1 row-index (+ mat0-col-dim column-index)) (aref mat1 row-index column-index))))
+      con-mat1)))
+
+(defun concatenate-matrix-diagonal-naive-impl
+  (&rest args)
+  (if (> (length args) 2)
+      (concatenate-matrix-diagonal-naive-impl
+       (car args)
+       (apply #'concatenate-matrix-diagonal-naive-impl(cdr args)))
+    (let* ((mat0 (car args)) (mat1 (cadr args))
+           (mat0-row-dim (array-dimension mat0 0))
+           (mat0-col-dim (array-dimension mat0 1))
+           (mat1-row-dim (array-dimension mat1 0))
+           (mat1-col-dim (array-dimension mat1 1))
+           (con-mat1 (make-matrix (+ mat0-row-dim mat1-row-dim) (+ mat0-col-dim mat1-col-dim))))
+      (dotimes (row-index mat0-row-dim)
+        (dotimes (column-index mat0-col-dim)
+          (setf (aref con-mat1 row-index column-index) (aref mat0 row-index column-index))))
+      (dotimes (row-index mat1-row-dim)
+        (dotimes (column-index mat1-col-dim)
+          (setf (aref con-mat1 (+ mat0-row-dim row-index) (+ mat0-col-dim column-index)) (aref mat1 row-index column-index))))
+      con-mat1)))
+
+;; Test functions
+(defun test-matrix-concatenate-single-common
+  (func
+   &key (random-max-dim 100)
+        (mat-row-dim (1+ (random random-max-dim))) (mat-column-dim (1+ (random random-max-dim))))
+  "Test matrix concatenate functions for single matrix argument."
+  (let ((mat (make-random-matrix mat-row-dim mat-column-dim)))
+    (= (norm (array-entity (m- (funcall func mat) mat))) 0.0)))
+
+(defun test-matrix-concatenate-matrix-column
+  (&key (matrix-list-length (+ 2 (random 5))))
+  (let ((mats (make-random-matrix-list matrix-list-length :same-column-p t)))
+    (=
+     (norm (array-entity
+            (m- (apply #'concatenate-matrix-column mats)
+                (apply #'concatenate-matrix-column-naive-impl mats))))
+     0)))
+
+(defun test-matrix-concatenate-matrix-row
+  (&key (matrix-list-length (+ 2 (random 5))))
+  (let ((mats (make-random-matrix-list matrix-list-length :same-row-p t)))
+    (=
+     (norm (array-entity
+            (m- (apply #'concatenate-matrix-row mats)
+                (apply #'concatenate-matrix-row-naive-impl mats))))
+     0)))
+
+(defun test-matrix-concatenate-matrix-diagonal
+  (&key (matrix-list-length (+ 2 (random 5))))
+  (let ((mats (make-random-matrix-list matrix-list-length)))
+    (=
+     (norm (array-entity
+            (m- (apply #'concatenate-matrix-diagonal mats)
+                (apply #'concatenate-matrix-diagonal-naive-impl mats))))
+     0)))
+
+(deftest test-matrix-concatenate-noargs
+  (assert (and (not (concatenate-matrix-column))
+               (not (concatenate-matrix-row))
+               (not (concatenate-matrix-diagonal)))))
+
+(deftest test-matrix-concatenate-single-matrix
+  (assert (and
+           (test-matrix-concatenate-single-common #'concatenate-matrix-column)
+           (test-matrix-concatenate-single-common #'concatenate-matrix-row)
+           (test-matrix-concatenate-single-common #'concatenate-matrix-diagonal))))
+
+(deftest test-matrix-concatenate-multiple-matrices
+  (assert (and
+           (every #'identity (mapcar #'(lambda (x) (test-matrix-concatenate-matrix-row)) (make-list 50)))
+           (every #'identity (mapcar #'(lambda (x) (test-matrix-concatenate-matrix-column)) (make-list 50)))
+           (every #'identity (mapcar #'(lambda (x) (test-matrix-concatenate-matrix-diagonal)) (make-list 50)))
+           )))
+
 (run-all-tests)
 (exit)


### PR DESCRIPTION
I'd like to add concatenate matrix functions from `euslib/jsk/jsk.l`.
I refined the code:
- Add documentation string.
- Add column and row size check.

Without this PR, we can set matrix components by using `dotimes` and `aref`.
However, it increases the amount of codes and it causes too many bugs from invalid indexing.