### PR TITLE
Add print message

### DIFF
--- a/irteus/demo/closed-loop.l
+++ b/irteus/demo/closed-loop.l
@@ -202,7 +202,7 @@
                 )
             (reverse cylinder-length-list) (reverse link-angle-list))
     ))
-(warn "(test-sample-1dof-closed-link-robot)~%")
+(warn "(test-sample-1dof-closed-link-robot) ;; Example for 1dof closed-link robot.~%")
 
 (defun test-sample-2dof-closed-link-robot
   ()
@@ -251,5 +251,5 @@
                 )
             (reverse cylinder-length-list) (reverse link-angle-list))
     ))
-(warn "(test-sample-2dof-closed-link-robot)~%")
+(warn "(test-sample-2dof-closed-link-robot) ;; Example for 2dof closed-link robot.~%")
 

--- a/irteus/demo/crank-motion.l
+++ b/irteus/demo/crank-motion.l
@@ -119,4 +119,4 @@
       )))
 
 (unless (boundp '*irtviewer*) (make-irtviewer))
-(warn "(crank-motion) for fullbody motion~%")
+(warn "(crank-motion) ;; for fullbody motion~%")

--- a/irteus/demo/dual-arm-ik.l
+++ b/irteus/demo/dual-arm-ik.l
@@ -98,4 +98,4 @@
      )
     ))
 (unless (boundp '*irtviewer*) (make-irtviewer))
-(warn "(dual-arm-ik) for tool usage~%")
+(warn "(dual-arm-ik) ;; for tool usage~%")

--- a/irteus/demo/dual-manip-ik.l
+++ b/irteus/demo/dual-manip-ik.l
@@ -84,6 +84,6 @@
     ))
 
 (unless (boundp '*irtviewer*) (make-irtviewer))
-(warn "(dual-manip-ik) for dual-armed object manipulation~%")
+(warn "(dual-manip-ik) ;; for dual-armed object manipulation~%")
 
 

--- a/irteus/demo/full-body-ik.l
+++ b/irteus/demo/full-body-ik.l
@@ -54,5 +54,5 @@
 
 ;;
 (unless (boundp '*irtviewer*) (make-irtviewer))
-(warn "(full-body-ik) for humanoid~%")
+(warn "(full-body-ik) ;; for humanoid~%")
 

--- a/irteus/demo/hand-grasp-ik.l
+++ b/irteus/demo/hand-grasp-ik.l
@@ -78,4 +78,4 @@
     ))
 
 (unless (boundp '*irtviewer*) (make-irtviewer))
-(warn "(hand-grasp) for hand model~%")
+(warn "(hand-grasp) ;; for hand model~%")

--- a/irteus/demo/hanoi-arm.l
+++ b/irteus/demo/hanoi-arm.l
@@ -89,7 +89,7 @@
     ))
 
 (unless (boundp '*irtviewer*) (make-irtviewer))
-(warn "(hanoi-arm) for arm solving hanoi tower~%")
+(warn "(hanoi-arm) ;; for arm solving hanoi tower~%")
 
 
 

--- a/irteus/demo/null-space-ik.l
+++ b/irteus/demo/null-space-ik.l
@@ -64,5 +64,5 @@
 
 ;;
 (unless (boundp '*irtviewer*) (make-irtviewer))
-(warn "(null-space-ik) for humanoid~%")
+(warn "(null-space-ik) ;; for humanoid~%")
 

--- a/irteus/demo/particle.l
+++ b/irteus/demo/particle.l
@@ -225,5 +225,5 @@
   (sim-stop)
   (all-status))
 
-(warn "(particle) for particle simulation~%")
+(warn "(particle) ;; for particle simulation~%")
 

--- a/irteus/demo/special-joints.l
+++ b/irteus/demo/special-joints.l
@@ -150,5 +150,5 @@
       )
     (every #'identity (reverse ret))
     ))
-(warn "(test-interlocking-joint-arm)~%")
-(warn "(test-sample-legged-robot-with-interlocking-joints)~%")
+(warn "(test-interlocking-joint-arm) ;; Example for arm with interlocking joints~%")
+(warn "(test-sample-legged-robot-with-interlocking-joints) ;; Example for legged robots with interlocking joints~%")

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -237,7 +237,7 @@
                 (list :time tm :zmp zmp :cog cog :refzmp refzmp))
             tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
     ))
-(warn "(test-preview-control)~%")
+(warn "(test-preview-control) ;; Example for preview controller~%")
 
 ;; dynamics filter by using preview control
 ;;   input motion : control ZMP at 0 based on COG model
@@ -293,4 +293,4 @@
     (setq *robot* (instance sample-robot :init)))
   (test-preview-control-dynamics-filter *robot*)
   )
-(warn "(test-preview-control-dynamics-filter-for-sample-robot)~%")
+(warn "(test-preview-control-dynamics-filter-for-sample-robot) ;; Example for dynamics filter using preview controller~%")

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -77,8 +77,8 @@
   (unless (boundp '*robot*)
     (setq *robot* (instance sample-robot :init)))
   (walk-motion-single-support *robot*))
-(warn "(walk-motion-for-sample-robot) for walking motion~%")
-(warn "(walk-motion-single-support-for-sample-robot) for walking motion~%")
+(warn "(walk-motion-for-sample-robot) ;; for walking motion~%")
+(warn "(walk-motion-single-support-for-sample-robot) ;; for walking motion~%")
 
 (defun quad-walk-motion-for-sample-robot
   (gen-footstep-func &key (go-backward-over t))
@@ -159,7 +159,7 @@
                    (make-coords :coords (send (send *robot* :rarm :end-coords :copy-worldcoords) :translate (float-vector 200 100 0) :world) :name :rarm))
              ))
    :go-backward-over go-backward-over))
-(warn "(trot-walk-motion-for-sample-robot) for walking motion~%")
+(warn "(trot-walk-motion-for-sample-robot) ;; for walking motion~%")
 
 (defun crawl-walk-motion-for-sample-robot
   (&key (go-backward-over t))
@@ -172,7 +172,7 @@
              (list (make-coords :coords (send (send *robot* :lleg :end-coords :copy-worldcoords) :translate (float-vector 50 0 0) :world) :name :lleg))
              ))
    :go-backward-over go-backward-over))
-(warn "(crawl-walk-motion-for-sample-robot) for walking motion~%")
+(warn "(crawl-walk-motion-for-sample-robot) ;; for walking motion~%")
 
 (defun walk-motion-for-robots ()
   (unless (boundp '*robots*)
@@ -189,7 +189,7 @@
               (walk-motion rb))
           *robots*)
   )
-(warn "(walk-motion-for-robots) for walking motion for several robot models~%")
+(warn "(walk-motion-for-robots) ;; for walking motion for several robot models~%")
 
 ;; preview control example
 (defun test-preview-control


### PR DESCRIPTION
- Add print message for demo function usage.
- Use `(demo-functoin) ;; comment`  instead of `(demo-functoin) comment` :
```
(full-body-ik) ;; for humanoid
(null-space-ik) ;; for humanoid
(dual-arm-ik) ;; for tool usage
(hand-grasp) ;; for hand model
(dual-manip-ik) ;; for dual-armed object manipulation
(crank-motion) ;; for fullbody motion
(walk-motion-for-sample-robot) ;; for walking motion
(walk-motion-single-support-for-sample-robot) ;; for walking motion
(trot-walk-motion-for-sample-robot) ;; for walking motion
(crawl-walk-motion-for-sample-robot) ;; for walking motion
(walk-motion-for-robots) ;; for walking motion for several robot models
(test-preview-control) ;; Example for preview controller
(test-preview-control-dynamics-filter-for-sample-robot) ;; Example for dynamics filter using preview controller
(hanoi-arm) ;; for arm solving hanoi tower
(particle) ;; for particle simulation
(test-sample-1dof-closed-link-robot) ;; Example for 1dof closed-link robot.
(test-sample-2dof-closed-link-robot) ;; Example for 2dof closed-link robot.
(test-interlocking-joint-arm) ;; Example for arm with interlocking joints
(test-sample-legged-robot-with-interlocking-joints) ;; Example for legged robots with interlocking joints
```