### PR TITLE
Update dump-command of :inverse-kinematics

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2131,11 +2131,15 @@
                           (t (make-list (length move-target) :initial-element (deg2rad 1)))))
                   (union-link-list)
 		  (centroid-thre 1.0) (target-centroid-pos) (centroid-offset-func) (cog-translation-axis :z) (cog-null-space nil)
-		  (dump-command t) (periodic-time 0.5) ;; [s]
+		  (dump-command :fail-only) (periodic-time 0.5) ;; [s]
                   (check-collision)
                   (additional-jacobi) (additional-vel)
 		  &allow-other-keys)
-   "Move move-target to target-coords."
+   "Move move-target to target-coords.
+    dump-command should be t, nil, or :fail-only.
+      t          : dump log both in success and fail.
+      :fail-only : dump log only in fail.
+      nil        : do not dump log."
    ;; target-coords, move-target, rotation-axis, translation-axis, link-list
    ;; -> both list and atom OK.
    (let* ((loop 0)

--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2261,14 +2261,19 @@
                    :update-mass-properties nil)))
         ;; update difference
      (mapcar #'(lambda (l a) (send l :analysis-level a)) union-link-list old-analysis-level)
-     ;; rename log file
+     ;; reset weight
+     (send self :reset-joint-angle-limit-weight-old union-link-list)
+     ;; Get final ik success result flag
+     (if check-collision (setq collision-status (send self :self-collision-check)))
+     (setq success (and (or success (not revert-if-fail)) (not collision-status)))
+     ;; Dump log
      (when (or (eq dump-command t)
-               (and (eq dump-command :fail-only) (not (or success (not revert-if-fail)))))
+               (and (eq dump-command :fail-only) (not success)))
        (setq command-directory
 	     (format nil "/tmp/irtmodel-ik-~A" (unix::getpid))
 	     command-id
 	     (let ((lt (unix::localtime))) (substitute #\0 #\  (format nil "~A-~04d-~02d-~02d-~02d-~02d-~02d" (send (class self) :name) (+ 1900 (elt lt 5)) (+ 1 (elt lt 4)) (elt lt 3) (elt lt 2) (elt lt 1) (elt lt 0))))
-             command-filename (format nil "~A/~A-~A.l" command-directory command-id (if (or success (not revert-if-fail)) "success" "failure")))
+             command-filename (format nil "~A/~A-~A.l" command-directory command-id (if success "success" "failure")))
        (unix::mkdir command-directory)
        (with-open-file
 	(f command-filename :direction :output)
@@ -2276,11 +2281,8 @@
         (dump-structure f initial-target-coords)
         (dump-structure f initial-av)
         ))
-     ;; reset weight
-     (send self :reset-joint-angle-limit-weight-old union-link-list)
-     (if check-collision (setq collision-status (send self :self-collision-check)))
      ;; check solved or not
-     (if (and (or success (not revert-if-fail)) (not collision-status))
+     (if success
          (send self :angle-vector)
        (progn
 	 (when warnp

--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2149,7 +2149,11 @@
 	  ;;
           (success t) 
 	  (old-analysis-level (send-all union-link-list :analysis-level))
-          command-directory command-filename command-id ik-args collision-status)       
+          ik-args collision-status
+          ;; Parameters for log file
+          command-directory command-filename command-id
+          initial-target-coords initial-av initial-log-str
+          )       
      (send-all union-link-list :analysis-level :coords)
      ;; argument check
      (when (or (null link-list) (null move-target))
@@ -2157,27 +2161,18 @@
        (return-from :inverse-kinematics t))
      (if (and (null translation-axis) (null rotation-axis))
          (return-from :inverse-kinematics t))
-     ;; setup fname for log
+     ;; setup initial parameters for logging
      (when dump-command
-       (setq command-directory
-	     (format nil "/tmp/irtmodel-ik-~A" (unix::getpid))
-	     command-id
-	     (let ((lt (unix::localtime))) (substitute #\0 #\  (format nil "~A-~04d-~02d-~02d-~02d-~02d-~02d" (send (class self) :name) (+ 1900 (elt lt 5)) (+ 1 (elt lt 4)) (elt lt 3) (elt lt 2) (elt lt 1) (elt lt 0))))
-	     command-filename
-	     (format nil "~A/~A.l" command-directory command-id))
-       (unix::mkdir command-directory)
-       (with-open-file
-	(f (format nil "~A/~A.l" command-directory command-id) :direction :output)
-	(format f ";; ik ~A log at ~A on ~A~%;;~%" (if success "success" "fail") (string-trim '(10) (unix:asctime (unix:localtime))) lisp::lisp-implementation-version)
-	(format f ";; link-list ~A~%" link-list)
-	(format f ";; move-target ~A~%" move-target)
-	(format f ";; rotatoin-axis ~A, translation-axis ~A~%" rotation-axis translation-axis)
-	(format f ";; thre ~A, rthre ~A, stop ~A~%" thre rthre stop)
-	(if (atom target-coords)
-	    (dump-structure f `(setq c0 ,target-coords))
-	  (dump-structure f `(setq c0 ',(mapcar #'(lambda (x) x) target-coords))))
-	(dump-structure f `(setq av0 ,(send self :angle-vector)))
-	))
+	(setq initial-log-str
+              (format nil ";; ik ~A log at ~A on ~A~%;;~%" (if success "success" "fail") (string-trim '(10) (unix:asctime (unix:localtime))) lisp::lisp-implementation-version))
+        (setq initial-log-str (format nil "~A;; link-list ~A~%" initial-log-str link-list))
+	(setq initial-log-str (format nil "~A;; move-target ~A~%" initial-log-str move-target))
+	(setq initial-log-str (format nil "~A;; rotatoin-axis ~A, translation-axis ~A~%" initial-log-str rotation-axis translation-axis))
+	(setq initial-log-str (format nil "~A;; thre ~A, rthre ~A, stop ~A~%" initial-log-str thre rthre stop))
+        (if (atom target-coords)
+            (setq initial-target-coords `(setq c0 ,target-coords))
+          (setq initial-target-coords `(setq c0 ',(mapcar #'(lambda (x) x) target-coords))))
+        (setq initial-av `(setq av0 ,(send self :angle-vector))))
      ;; atom -> list
      (when debug-view
        (if (atom debug-view) (setq debug-view (list debug-view)))
@@ -2267,8 +2262,20 @@
         ;; update difference
      (mapcar #'(lambda (l a) (send l :analysis-level a)) union-link-list old-analysis-level)
      ;; rename log file
-     (when dump-command
-       (unix::rename (format nil "~A/~A.l" command-directory command-id ) (setq command-filename (format nil "~A/~A-~A.l" command-directory command-id (if (or success (not revert-if-fail)) "success" "failure")))))
+     (when (or (eq dump-command t)
+               (and (eq dump-command :fail-only) (not (or success (not revert-if-fail)))))
+       (setq command-directory
+	     (format nil "/tmp/irtmodel-ik-~A" (unix::getpid))
+	     command-id
+	     (let ((lt (unix::localtime))) (substitute #\0 #\  (format nil "~A-~04d-~02d-~02d-~02d-~02d-~02d" (send (class self) :name) (+ 1900 (elt lt 5)) (+ 1 (elt lt 4)) (elt lt 3) (elt lt 2) (elt lt 1) (elt lt 0))))
+             command-filename (format nil "~A/~A-~A.l" command-directory command-id (if (or success (not revert-if-fail)) "success" "failure")))
+       (unix::mkdir command-directory)
+       (with-open-file
+	(f command-filename :direction :output)
+        (format f "~A" initial-log-str)
+        (dump-structure f initial-target-coords)
+        (dump-structure f initial-av)
+        ))
      ;; reset weight
      (send self :reset-joint-angle-limit-weight-old union-link-list)
      (if check-collision (setq collision-status (send self :self-collision-check)))

--- a/irteus/test/test-irt-motion.l
+++ b/irteus/test/test-irt-motion.l
@@ -406,6 +406,35 @@
            )))
    ))
 
+(defun test-ik-fail-log-with-dump-command-args-common
+  (robot)
+  (let ((log-directory (format nil "/tmp/irtmodel-ik-~A" (unix::getpid))) (ret))
+    (labels ((test-ik-with-log
+              (target-pos dump-command)
+              (unix:system (format nil "rm -f /tmp/irtmodel-ik-~A/*" (unix::getpid)))
+              (send robot :reset-pose)
+              (send robot :newcoords (make-coords))
+              (send robot :rarm :move-end-pos target-pos :world :debug-view :no-message :stop 10 :dump-command dump-command)))
+      ;; dump-command nil => no log files are generated.
+      (test-ik-with-log #f(10 0 0) nil)
+      (push (not (find-if #'(lambda (x) (substringp ".l" x)) (directory log-directory))) ret)
+      (test-ik-with-log #f(10000 0 0) nil)
+      (push (not (find-if #'(lambda (x) (substringp ".l" x)) (directory log-directory))) ret)
+      ;; dump-command :fail-only => log files are generated only if ik fail.
+      (test-ik-with-log #f(10 0 0) :fail-only)
+      (push (not (find-if #'(lambda (x) (substringp ".l" x)) (directory log-directory))) ret)
+      (test-ik-with-log #f(10000 0 0) :fail-only)
+      (push (find-if #'(lambda (x) (substringp ".l" x)) (directory log-directory)) ret)
+      ;; dump-command t => log files are generated always.
+      (test-ik-with-log #f(10 0 0) t)
+      (push (find-if #'(lambda (x) (substringp ".l" x)) (directory log-directory)) ret)
+      (test-ik-with-log #f(10000 0 0) t)
+      (push (find-if #'(lambda (x) (substringp ".l" x)) (directory log-directory)) ret)
+      ;; return
+      (unix:system (format nil "rm -f /tmp/irtmodel-ik-~A/*" (unix::getpid)))
+      (reverse ret)
+      )))
+
 ;; check torque calculation comparing methods to calculate ext-force and ext-moment and robot root-link configuration
 (defun draw-objects-torque
   (robot tq)
@@ -745,6 +774,9 @@
 
 (deftest test-load-ik-fail-log-dual-arm-ik-for-sample-robot
   (assert (test-load-ik-fail-log-dual-arm-ik-common *sample-robot*)))
+
+(deftest test-ik-fail-log-with-dump-command-args-for-sample-robot
+  (assert (every #'identity (test-ik-fail-log-with-dump-command-args-common *sample-robot*))))
 
 (deftest test-all-for-arm-robot-static-1
   (assert


### PR DESCRIPTION
Update dump-command of :inverse-kinematics 
because dump command takes time to execute:
https://github.com/euslisp/jskeus/commit/8f9e79e4f24b86cc66fdf3d4bec1a71b878b099e#commitcomment-12334678

Update is here:
- Use dump-command mode t, nil, and :fail-only. 
```
    dump-command should be t, nil, or :fail-only.                                                                                                                                                                      
      t          : dump log both in success and fail.                                                                                                                                                                  
      :fail-only : dump log only in fail.                                                                                                                                                                              
      nil        : do not dump log."
```
- Add test code to check whether adequate files are generated for all dump-command argument candidate.
- **Use :fail-only by default. This will change the behavior of logging.** 
