### PR TITLE
Update quad samples

### DIFF
--- a/irteus/demo/sample-robot-model.l
+++ b/irteus/demo/sample-robot-model.l
@@ -66,7 +66,7 @@
 
      (setq jh0 (instance rotational-joint :init :parent-link (cadr torso) :child-link (car head) :name :head-neck-y :axis :z :min -150 :max 150))
      (setq jh1 (instance rotational-joint :init :parent-link (car head) :child-link (cadr head) :name :head-neck-p :axis :y))
-     (setq jal0 (instance rotational-joint :init :parent-link (cadr torso) :child-link (elt larm 0) :name :larm-shoulder-p :axis :y))
+     (setq jal0 (instance rotational-joint :init :parent-link (cadr torso) :child-link (elt larm 0) :name :larm-shoulder-p :axis :y :min -150 :max 150))
      (setq jal1 (instance rotational-joint :init :parent-link (elt larm 0) :child-link (elt larm 1) :name :larm-shoulder-r :axis :x :min -30 :max 180))
      (setq jal2 (instance rotational-joint :init :parent-link (elt larm 1) :child-link (elt larm 2) :name :larm-shoulder-y :axis :z))
      (setq jal3 (instance rotational-joint :init :parent-link (elt larm 2) :child-link (elt larm 3) :name :larm-elbow-p :axis :y :min -180 :max 0))
@@ -74,7 +74,7 @@
      (setq jal5 (instance rotational-joint :init :parent-link (elt larm 4) :child-link (elt larm 5) :name :larm-wrist-r :axis :x))
      (setq jal6 (instance rotational-joint :init :parent-link (elt larm 5) :child-link (elt larm 6) :name :larm-wrist-p :axis :y))
 
-     (setq jar0 (instance rotational-joint :init :parent-link (cadr torso)  :child-link (elt rarm 0) :name :rarm-shoulder-p :axis :y))
+     (setq jar0 (instance rotational-joint :init :parent-link (cadr torso)  :child-link (elt rarm 0) :name :rarm-shoulder-p :axis :y :min -150 :max 150))
      (setq jar1 (instance rotational-joint :init :parent-link (elt rarm 0) :child-link (elt rarm 1) :name :rarm-shoulder-r :axis :-x :min -30 :max 180))
      (setq jar2 (instance rotational-joint :init :parent-link (elt rarm 1) :child-link (elt rarm 2) :name :rarm-shoulder-y :axis :-z))
      (setq jar3 (instance rotational-joint :init :parent-link (elt rarm 2) :child-link (elt rarm 3) :name :rarm-elbow-p :axis :y :min -180 :max 0))
@@ -84,14 +84,14 @@
 
      (setq jll0 (instance rotational-joint :init :parent-link aroot-link :child-link (elt lleg 0) :name :lleg-crotch-y :axis :z))
      (setq jll1 (instance rotational-joint :init :parent-link (elt lleg 0) :child-link (elt lleg 1) :name :lleg-crotch-r :axis :x))
-     (setq jll2 (instance rotational-joint :init :parent-link (elt lleg 1) :child-link (elt lleg 2) :name :lleg-crotch-p :axis :y))
+     (setq jll2 (instance rotational-joint :init :parent-link (elt lleg 1) :child-link (elt lleg 2) :name :lleg-crotch-p :axis :y :min -120 :max 120))
      (setq jll3 (instance rotational-joint :init :parent-link (elt lleg 2) :child-link (elt lleg 3) :name :lleg-knee-p :axis :y :min 0))
      (setq jll4 (instance rotational-joint :init :parent-link (elt lleg 3) :child-link (elt lleg 4) :name :lleg-ankle-p :axis :y))
      (setq jll5 (instance rotational-joint :init :parent-link (elt lleg 4) :child-link (elt lleg 5) :name :lleg-ankle-r :axis :x))
 
      (setq jlr0 (instance rotational-joint :init :parent-link aroot-link :child-link (elt rleg 0) :name :rleg-crotch-y :axis :-z))
      (setq jlr1 (instance rotational-joint :init :parent-link (elt rleg 0) :child-link (elt rleg 1) :name :rleg-crotch-r :axis :-x))
-     (setq jlr2 (instance rotational-joint :init :parent-link (elt rleg 1) :child-link (elt rleg 2) :name :rleg-crotch-p :axis :y))
+     (setq jlr2 (instance rotational-joint :init :parent-link (elt rleg 1) :child-link (elt rleg 2) :name :rleg-crotch-p :axis :y :min -120 :max 120))
      (setq jlr3 (instance rotational-joint :init :parent-link (elt rleg 2) :child-link (elt rleg 3) :name :rleg-knee-p :axis :y :min 0))
      (setq jlr4 (instance rotational-joint :init :parent-link (elt rleg 3) :child-link (elt rleg 4) :name :rleg-ankle-p :axis :y))
      (setq jlr5 (instance rotational-joint :init :parent-link (elt rleg 4) :child-link (elt rleg 5) :name :rleg-ankle-r :axis :-x))

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -86,8 +86,10 @@
     (setq *robot* (instance sample-robot :init)))
   ;; initial quad pose
   (send *robot* :reset-pose)
-  (send *robot* :fix-leg-to-coords (make-coords))
-  (send *robot* :rotate (if go-backward-over -pi/2 pi/2) :y)
+  (send *robot* :move-coords
+        (make-coords :rpy (list 0 (if go-backward-over -pi/2 pi/2) 0)
+                     :pos (float-vector 0 0 300))
+        (car (send *robot* :links)))
   (let ((tc
          (if go-backward-over
              (list
@@ -96,21 +98,22 @@
               (make-coords :pos #f(-200 -120 0) :rpy (list 0 pi/2 0))
               (make-coords :pos #f(-200 120 0) :rpy (list 0 pi/2 0)))
            (list
-            (make-coords :pos #f(-300 -120 0))
-            (make-coords :pos #f(-300 120 0))
+            (make-coords :pos #f(-200 -120 0))
+            (make-coords :pos #f(-200 120 0))
             (make-coords :pos #f(200 -120 0) :rpy (list 0 pi/2 0))
             (make-coords :pos #f(200 120 0) :rpy (list 0 pi/2 0)))))
         (ik-args
-         (list :min (float-vector -1000 -1000 -1000 -90 -90 -90)
-               :max (float-vector  1000  1000  1000  90  90  90)
+         (list :min (float-vector -1e10 -1e10 -1e10 -180 -180 -180)
+               :max (float-vector  1e10  1e10  1e10  180  180  180)
                :joint-args '(:absolute-p t)
                :additional-nspace-list
                (list
                 (list (car (send *robot* :links))
                       #'(lambda () (send *robot* :joint-angle-limit-nspace-for-6dof :limbs '(:rarm :larm :rleg :lleg))))
                 )
+               ;;:min-loop 2 :cog-null-space nil
                :root-link-virtual-joint-weight #F(0.1 0.1 0.1 0.5 0.5 0.5)
-               :cog-gain 5.0 :stop 200 :centroid-thre 15
+               :cog-gain 5.0 :centroid-thre 15
                ;;:debug-view :no-message
                :collision-avoidance-link-pair nil)))
     (with-move-target-link-list
@@ -119,7 +122,6 @@
             tc
             :move-target mt :link-list ll
             :target-centroid-pos (vector-mean (send-all tc :worldpos))
-            :stop 400
             ik-args))
     ;; prepare footsteps
     (let ((footstep-list (funcall gen-footstep-func)))
@@ -135,9 +137,8 @@
                        (vector-mean (append (send *robot* :arms :end-coords :worldpos) (send *robot* :legs :end-coords :worldpos)))
                        ik-args))
             :solve-angle-vector-args
-            (append (list ;;:debug-view :no-message
-                          :centroid-thre 100
-                          :thre '(10 10 10 10)) ik-args)
+            ;;(append (list :debug-view :no-message) ik-args)
+            ik-args
             :default-step-height 70)
       )))
 


### PR DESCRIPTION
Update quad samples.
Update joint range of sample robot according to existent real robots.
Update quad sample  to avoid infeasible target cog.