### PR TITLE
Update preview controller classes, examples, and tests

### DIFF
--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -207,17 +207,15 @@
                             ((< tm 6) #f(20 -20 0))
                             (t #f(0 -20 0))))
                   tm-list))
-         zmp-list cog-list ref-zmp-list2)
+         zmp-list cog-list ref-zmp-list2
+         ret)
     (mapcar
-     #'(lambda (ref-zmp tm)
-         (let ((xk (send pc :update-xk ref-zmp)))
-           ;; (format t ";tm=~7,3f, u=~7,3f, p=~7,3f, xk=~30A~%"
-           ;;         tm (elt (matrix-row (send pc :calc-u) 0) 0) (elt (send pc :cart-zmp) 0) (elt (send pc :refcog) 0))
-           (push (elt (send pc :cart-zmp) 0) zmp-list) ;; zmp ;; this zmp is "zmp as a table-cart model"
-           (push (elt (send pc :refcog) 0) cog-list)                   ;; cog
-           (push (elt (send pc :current-refzmp) 0) ref-zmp-list2) ;; ref zmp ;; ref-zmp-list2 should be equal to ref-zmp-list
-           ))
-     ref-zmp-list tm-list)
+     #'(lambda (ret tm)
+         (push (elt (caddr ret) 0) zmp-list) ;; zmp ;; this zmp is "zmp as a table-cart model"
+         (push (elt (cadr ret) 0) cog-list)                   ;; cog
+         (push (elt (car ret) 0) ref-zmp-list2) ;; ref zmp ;; ref-zmp-list2 should be equal to ref-zmp-list
+         )
+     (send pc :pass-preview-controller ref-zmp-list) tm-list)
     (with-open-file
      (f "/tmp/test-preview-control-data.dat" :direction :output)
      (mapcar #'(lambda (tm zmp cog refzmp)

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -198,7 +198,7 @@
         (q 1) (r 1e-6))
   "Example for preview controller in walking ZMP input."
   (let* ((dt 0.010) (max-tm 10.0)
-         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class))
+         (pc (instance preview-control-cart-table-cog-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class))
          (tm-list (mapcar #'(lambda (x) (* x dt))
                           (let ((i 0)) (mapcar #'(lambda (x) (incf i)) (make-list (round (/ max-tm dt)))))))
          (ref-zmp-list
@@ -251,7 +251,7 @@
                             ((< tm 6) (midpoint (/ (- tm 2) 4.0) #f(-20 20 0) #f(20 -20 0)))
                             (t #f(20 -20 0))))
                   tm-list))
-         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class :init-xk (car ref-zmp-list)))
+         (pc (instance preview-control-cart-table-cog-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class :init-xk (car ref-zmp-list)))
          zmp-list cog-list ref-zmp-list2
          ret)
     (mapcar
@@ -304,7 +304,7 @@
                        (float-vector 100 100 0) ;; neutoral zmp
                        ))
                   tm-list))
-         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class :init-xk (car ref-zmp-list)))
+         (pc (instance preview-control-cart-table-cog-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class :init-xk (car ref-zmp-list)))
          zmp-list cog-list ref-zmp-list2
          ret)
     (mapcar
@@ -340,7 +340,7 @@
         (q 1) (r 1e-6))
   "Example for preview controller in long walking ZMP input."
   (let* ((dt 0.010) (max-tm 20.0)
-         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class))
+         (pc (instance preview-control-cart-table-cog-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class))
          (tm-list (mapcar #'(lambda (x) (* x dt))
                           (let ((i 0)) (mapcar #'(lambda (x) (incf i)) (make-list (round (/ max-tm dt)))))))
          (tmp-zmp (float-vector 0 0 0))

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -194,10 +194,10 @@
 
 ;; preview control example
 (defun test-preview-control
-  (&key (preview-class preview-controller-base)
+  (&key (preview-controller-class preview-controller)
         (q 1) (r 1e-6))
   (let* ((dt 0.010) (max-tm 10.0)
-         (pc (instance preview-control :init dt 800 :q q :r r :preview-controller-class preview-class))
+         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class))
          (tm-list (mapcar #'(lambda (x) (* x dt))
                           (let ((i 0)) (mapcar #'(lambda (x) (incf i)) (make-list (round (/ max-tm dt)))))))
          (ref-zmp-list
@@ -244,7 +244,7 @@
 ;;   input motion : control ZMP at 0 based on COG model
 ;;   output motion : control ZMP at 0 based on multi-body model
 (defun test-preview-control-dynamics-filter
-  (robot &key (preview-class preview-controller-base) (cog-method :move-base-pos) (dt 0.025))
+  (robot &key (preview-controller-class preview-controller) (cog-method :move-base-pos) (dt 0.025))
   (let ((avs))
     (objects (list robot))
     ;; generate input motion control ZMP at 0, which corresponds to COG at 0 in this case
@@ -259,7 +259,7 @@
             avs))
     (setq avs (reverse avs))
     ;; filtering
-    (let ((data (subseq (send robot :preview-control-dynamics-filter dt avs :preview-class preview-class) 4)))
+    (let ((data (subseq (send robot :preview-control-dynamics-filter dt avs :preview-controller-class preview-controller-class) 4)))
       (with-open-file
        (f "/tmp/test-preview-control-data-2.dat" :direction :output)
        (mapcar #'(lambda (tm ozmp-x izmp-x ocog-x icog-x ozmp-y izmp-y ocog-y icog-y)
@@ -289,9 +289,9 @@
       )))
 
 (defun test-preview-control-dynamics-filter-for-sample-robot
-  (&key (preview-class preview-controller-base))
+  (&key (preview-controller-class preview-controller))
   (unless (boundp '*robot*)
     (setq *robot* (instance sample-robot :init)))
-  (test-preview-control-dynamics-filter *robot* :preview-class preview-class)
+  (test-preview-control-dynamics-filter *robot* :preview-controller-class preview-controller-class)
   )
 (warn "(test-preview-control-dynamics-filter-for-sample-robot) ;; Example for dynamics filter using preview controller~%")

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -193,9 +193,10 @@
 (warn "(walk-motion-for-robots) ;; for walking motion for several robot models~%")
 
 ;; preview control example
-(defun test-preview-control
+(defun test-preview-control-0
   (&key (preview-controller-class preview-controller)
         (q 1) (r 1e-6))
+  "Example for preview controller in walking ZMP input."
   (let* ((dt 0.010) (max-tm 10.0)
          (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class))
          (tm-list (mapcar #'(lambda (x) (* x dt))
@@ -236,7 +237,154 @@
                 (list :time tm :zmp zmp :cog cog :refzmp refzmp))
             tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
     ))
-(warn "(test-preview-control) ;; Example for preview controller~%")
+
+(defun test-preview-control-1
+  (&key (preview-controller-class preview-controller)
+        (q 1) (r 1e-6))
+  "Example for preview controller in linear ZMP transition."
+  (let* ((dt 0.010) (max-tm 8.0)
+         (tm-list (mapcar #'(lambda (x) (* x dt))
+                          (let ((i 0)) (mapcar #'(lambda (x) (incf i)) (make-list (round (/ max-tm dt)))))))
+         (ref-zmp-list
+          (mapcar #'(lambda (tm)
+                      (cond ((< tm 2) (midpoint (/ tm 2.0) #f(100 0 0) #f(-20 20 0)))
+                            ((< tm 6) (midpoint (/ (- tm 2) 4.0) #f(-20 20 0) #f(20 -20 0)))
+                            (t #f(20 -20 0))))
+                  tm-list))
+         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class :init-xk (car ref-zmp-list)))
+         zmp-list cog-list ref-zmp-list2
+         ret)
+    (mapcar
+     #'(lambda (ret tm)
+         (push (elt (caddr ret) 0) zmp-list) ;; zmp ;; this zmp is "zmp as a table-cart model"
+         (push (elt (cadr ret) 0) cog-list)                   ;; cog
+         (push (elt (car ret) 0) ref-zmp-list2) ;; ref zmp ;; ref-zmp-list2 should be equal to ref-zmp-list
+         )
+     (send pc :pass-preview-controller ref-zmp-list) tm-list)
+    (with-open-file
+     (f "/tmp/test-preview-control-data.dat" :direction :output)
+     (mapcar #'(lambda (tm zmp cog refzmp)
+                 (format f "~A ~A ~A ~A~%" tm zmp cog refzmp))
+             tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
+     )
+    (unless (or (null x::*display*) (= x::*display* 0))
+      (let ((gp-command-list (list
+                              "set xlabel 'Time [s]';"
+                              "set ylabel 'ZMP X [mm]';"
+                              "plot '/tmp/test-preview-control-data.dat' using 1:2 title 'cart zmp' with lines;"
+                              "replot '/tmp/test-preview-control-data.dat' using 1:3 title 'cog' with lines;"
+                              "replot '/tmp/test-preview-control-data.dat' using 1:4 title 'refzmp' with lines;"
+                              "pause -1;")))
+        (unix:system (format nil "gnuplot -e \"~A\""
+                             (let ((str "")) (dolist (gpc gp-command-list) (setq str (format nil "~A ~A" str gpc))) str)))))
+    (mapcar #'(lambda (tm zmp cog refzmp)
+                (list :time tm :zmp zmp :cog cog :refzmp refzmp))
+            tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
+    ))
+
+(defun test-preview-control-2
+  (&key (preview-controller-class preview-controller)
+        (q 1) (r 1e-6)
+        (ext-force-time 0.04) ;; [s]
+        (ext-force-height 800) ;; [m]
+        (ext-force-x -50)) ;; [N]
+  "Example for preview controller to keep balance against for impulsive external force."
+  (let* ((dt 0.010) (max-tm 5.0)
+         (tm-list (mapcar #'(lambda (x) (* x dt))
+                          (let ((i 0)) (mapcar #'(lambda (x) (incf i)) (make-list (round (/ max-tm dt)))))))
+         (ref-zmp-list
+          (mapcar #'(lambda (tm)
+                      (v+
+                       (float-vector (cond
+                                      ((< tm 2.0) 0)
+                                      ((< tm (+ ext-force-time 2.0))
+                                       (* -1 (* 1e-3 ext-force-height) ext-force-x)) ;; ZMP difference according to disturbance force
+                                      (t 0))
+                                     0 0)
+                       (float-vector 100 100 0) ;; neutoral zmp
+                       ))
+                  tm-list))
+         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class :init-xk (car ref-zmp-list)))
+         zmp-list cog-list ref-zmp-list2
+         ret)
+    (mapcar
+     #'(lambda (ret tm)
+         (push (elt (caddr ret) 0) zmp-list) ;; zmp ;; this zmp is "zmp as a table-cart model"
+         (push (elt (cadr ret) 0) cog-list)                   ;; cog
+         (push (elt (car ret) 0) ref-zmp-list2) ;; ref zmp ;; ref-zmp-list2 should be equal to ref-zmp-list
+         )
+     (send pc :pass-preview-controller ref-zmp-list) tm-list)
+    (with-open-file
+     (f "/tmp/test-preview-control-data.dat" :direction :output)
+     (mapcar #'(lambda (tm zmp cog refzmp)
+                 (format f "~A ~A ~A ~A~%" tm zmp cog refzmp))
+             tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
+     )
+    (unless (or (null x::*display*) (= x::*display* 0))
+      (let ((gp-command-list (list
+                              "set xlabel 'Time [s]';"
+                              "set ylabel 'ZMP X [mm]';"
+                              "plot '/tmp/test-preview-control-data.dat' using 1:2 title 'cart zmp' with lines;"
+                              "replot '/tmp/test-preview-control-data.dat' using 1:3 title 'cog' with lines;"
+                              "replot '/tmp/test-preview-control-data.dat' using 1:4 title 'refzmp' with lines;"
+                              "pause -1;")))
+        (unix:system (format nil "gnuplot -e \"~A\""
+                             (let ((str "")) (dolist (gpc gp-command-list) (setq str (format nil "~A ~A" str gpc))) str)))))
+    (mapcar #'(lambda (tm zmp cog refzmp)
+                (list :time tm :zmp zmp :cog cog :refzmp refzmp))
+            tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
+    ))
+
+(defun test-preview-control-3
+  (&key (preview-controller-class preview-controller)
+        (q 1) (r 1e-6))
+  "Example for preview controller in long walking ZMP input."
+  (let* ((dt 0.010) (max-tm 20.0)
+         (pc (instance preview-control-cogxy-trajectory-generator :init dt 800 :q q :r r :preview-controller-class preview-controller-class))
+         (tm-list (mapcar #'(lambda (x) (* x dt))
+                          (let ((i 0)) (mapcar #'(lambda (x) (incf i)) (make-list (round (/ max-tm dt)))))))
+         (tmp-zmp (float-vector 0 0 0))
+         (step-tm 1.0)
+         (ref-zmp-list
+          (mapcar #'(lambda (tm)
+                      (if (and (eps= (- (/ tm step-tm) (round (/ tm step-tm))) 0.0) (< tm 19.0))
+                          (setq tmp-zmp (v+ tmp-zmp (float-vector 100 50 0))))
+                      tmp-zmp)
+                  tm-list))
+         zmp-list cog-list ref-zmp-list2
+         ret)
+    (mapcar
+     #'(lambda (ret tm)
+         (push (elt (caddr ret) 0) zmp-list) ;; zmp ;; this zmp is "zmp as a table-cart model"
+         (push (elt (cadr ret) 0) cog-list)                   ;; cog
+         (push (elt (car ret) 0) ref-zmp-list2) ;; ref zmp ;; ref-zmp-list2 should be equal to ref-zmp-list
+         )
+     (send pc :pass-preview-controller ref-zmp-list) tm-list)
+    (with-open-file
+     (f "/tmp/test-preview-control-data.dat" :direction :output)
+     (mapcar #'(lambda (tm zmp cog refzmp)
+                 (format f "~A ~A ~A ~A~%" tm zmp cog refzmp))
+             tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
+     )
+    (unless (or (null x::*display*) (= x::*display* 0))
+      (let ((gp-command-list (list
+                              "set xlabel 'Time [s]';"
+                              "set ylabel 'ZMP X [mm]';"
+                              "plot '/tmp/test-preview-control-data.dat' using 1:2 title 'cart zmp' with lines;"
+                              "replot '/tmp/test-preview-control-data.dat' using 1:3 title 'cog' with lines;"
+                              "replot '/tmp/test-preview-control-data.dat' using 1:4 title 'refzmp' with lines;"
+                              "pause -1;")))
+        (unix:system (format nil "gnuplot -e \"~A\""
+                             (let ((str "")) (dolist (gpc gp-command-list) (setq str (format nil "~A ~A" str gpc))) str)))))
+    (mapcar #'(lambda (tm zmp cog refzmp)
+                (list :time tm :zmp zmp :cog cog :refzmp refzmp))
+            tm-list (reverse zmp-list) (reverse cog-list) (reverse ref-zmp-list2))
+    ))
+
+(warn "(test-preview-control-0) ;; ~A~%" (documentation 'test-preview-control-0))
+(warn "(test-preview-control-1) ;; ~A~%" (documentation 'test-preview-control-1))
+(warn "(test-preview-control-2) ;; ~A~%" (documentation 'test-preview-control-2))
+(warn "(test-preview-control-3) ;; ~A~%" (documentation 'test-preview-control-3))
 
 ;; dynamics filter by using preview control
 ;;   input motion : control ZMP at 0 based on COG model

--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -194,10 +194,10 @@
 
 ;; preview control example
 (defun test-preview-control
-  (&key (preview-class preview-control)
+  (&key (preview-class preview-controller-base)
         (q 1) (r 1e-6))
   (let* ((dt 0.010) (max-tm 10.0)
-         (pc (instance preview-class :init dt 800 :q q :r r))
+         (pc (instance preview-control :init dt 800 :q q :r r :preview-controller-class preview-class))
          (tm-list (mapcar #'(lambda (x) (* x dt))
                           (let ((i 0)) (mapcar #'(lambda (x) (incf i)) (make-list (round (/ max-tm dt)))))))
          (ref-zmp-list
@@ -211,8 +211,8 @@
     (mapcar
      #'(lambda (ref-zmp tm)
          (let ((xk (send pc :update-xk ref-zmp)))
-           (format t ";tm=~7,3f, u=~7,3f, p=~7,3f, xk=~30A~%"
-                   tm (elt (matrix-row (send pc :calc-u) 0) 0) (elt (send pc :cart-zmp) 0) (elt (send pc :refcog) 0))
+           ;; (format t ";tm=~7,3f, u=~7,3f, p=~7,3f, xk=~30A~%"
+           ;;         tm (elt (matrix-row (send pc :calc-u) 0) 0) (elt (send pc :cart-zmp) 0) (elt (send pc :refcog) 0))
            (push (elt (send pc :cart-zmp) 0) zmp-list) ;; zmp ;; this zmp is "zmp as a table-cart model"
            (push (elt (send pc :refcog) 0) cog-list)                   ;; cog
            (push (elt (send pc :current-refzmp) 0) ref-zmp-list2) ;; ref zmp ;; ref-zmp-list2 should be equal to ref-zmp-list
@@ -244,7 +244,7 @@
 ;;   input motion : control ZMP at 0 based on COG model
 ;;   output motion : control ZMP at 0 based on multi-body model
 (defun test-preview-control-dynamics-filter
-  (robot &key (preview-class preview-control) (cog-method :move-base-pos) (dt 0.025))
+  (robot &key (preview-class preview-controller-base) (cog-method :move-base-pos) (dt 0.025))
   (let ((avs))
     (objects (list robot))
     ;; generate input motion control ZMP at 0, which corresponds to COG at 0 in this case
@@ -289,7 +289,7 @@
       )))
 
 (defun test-preview-control-dynamics-filter-for-sample-robot
-  (&key (preview-class preview-control))
+  (&key (preview-class preview-controller-base))
   (unless (boundp '*robot*)
     (setq *robot* (instance sample-robot :init)))
   (test-preview-control-dynamics-filter *robot* :preview-class preview-class)

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1185,7 +1185,7 @@
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; preview-control class
+;;; preview-controller class
 ;;;  A, b, c -> system configuration matrices
 ;;;  uk -> input for controller at the time "k"
 ;;;  xk -> state variable
@@ -1200,9 +1200,9 @@
   :slots (xk uk delay f1-n y1-n dim queue-index initialize-queue-p additional-data-queue finishedp initialized-p))
 (defmethod preview-controller
   (:init
-    (dt ; dt -> sampling time[s]
+    (dt
      &key (q) (r)
-          ((:delay d)) ;; [s]
+          ((:delay d))
           ((:dim tmp-dim))
           (init-xk (float-vector 0 0 0))
           ((:A _A))
@@ -1210,6 +1210,13 @@
           ((:C _C))
           (state-dim (array-dimension _A 0))
           ((:initialize-queue-p iqp)))
+    "Initialize preview-controller.
+     Q is weighting of output error and R is weighting of input.
+     dt is sampling time [s].
+     delay is preview time [s].
+     init-xk is initial state value.
+     A, B, C are state eq matrices.
+     If initialize-queue-p is t, fill all queue by the first input at the begenning, otherwise, do not fill queue at the first."
     (setq delay (round (/ d dt)) dim tmp-dim initialize-queue-p iqp)
     (send-super :init _A _B _C q r)
     (setq queue-index 0)
@@ -1219,8 +1226,6 @@
     (send self :solve)
     (send self :calc-f)
     self)
-  ;; getter methods
-  (:delay () delay)
   (:calc-f () ;; calculate preview gain for k+1, ... k+N.
     (setq f1-n (make-matrix 1 (1+ delay))) ;; (matrix-row f1-n 0) is dummy to being mutiplied by p1-n
     (let* ((gsi (unit-matrix (array-dimension c 1)))
@@ -1236,7 +1241,11 @@
   (:calc-xk () ;; update xk+1
     (setq xk (m+ (m* A xk) (m* b (send self :calc-u)))))
   ;;
-  (:update-xk (p &optional (add-data))
+  (:update-xk
+   (p &optional (add-data))
+   "Update xk by inputting reference output.
+    Return value : nil (initializing) => return values (middle) => nil (finished)
+    If p is nil, automatically the last value in queue is used as input and preview controller starts finishing."
     ;; initialize
     (if p
         (progn
@@ -1274,25 +1283,37 @@
               (send self :current-state-vector)
               (send self :current-output-vector)))
     )
-  (:finishedp () finishedp)
+  (:finishedp
+   ()
+   "Finished or not."
+   finishedp)
   (:last-reference-output-vector
    ()
+   "Last value of reference output queue vector (y_{k+N}^{ref}).
+    Last value is latest future value."
    (matrix-row y1-n delay)) ;; tail of queue
   (:current-reference-output-vector
    ()
+   "First value of reference output queue vector (y_k^{ref}).
+    First value is oldest future value and it can be used as current reference value."
    (matrix-row y1-n 0)) ;; head of queue
   (:current-state-vector
    ()
+   "Current state value (xk)."
    (matrix-row xk 0))
   (:current-output-vector
    ()
+   "Current output value (yk)."
    (m* c xk))
   (:current-additional-data
    ()
+   "Current additional data value.
+    First value of additional-data-queue."
    (car additional-data-queue)
    )
   (:pass-preview-controller
    (reference-output-vector-list)
+   "Get preview controller results from reference-output-vector-list and returns list."
    (let ((r) (ret))
      ;; Wait until initialize
      (while (not (setq r (send self :update-xk (pop reference-output-vector-list) nil))))
@@ -1305,10 +1326,10 @@
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; extended-preview-control class
+;;; extended-preview-controller class
 ;;;  this class is error system of preview-control class
 ;;;  (refer to "Digital Preview Control (in Japanese)", SangyoToshoKabusikiGaisha, Takeshi Tsuchiya and Tadashi Egami)
-;;;  orgA, orgb, orgc -> system configuration matrices for original table-cart model
+;;;  orgA, orgb, orgc -> system configuration matrices
 ;;;  xk* -> [y_k^T, dxk^T]^T
 ;;;  state equation of this system is
 ;;;   xk+1* = A xk* + b duk
@@ -1326,6 +1347,13 @@
           ((:A _orgA)) ((:B _orgB)) ((:C _orgC))
           (state-dim (array-dimension _orgA 0))
           ((:initialize-queue-p iqp)))
+    "Initialize preview-controller in extended system (error system).
+     Q is weighting of output error and R is weighting of input.
+     dt is sampling time [s].
+     delay is preview time [s].
+     init-xk is initial state value.
+     A, B, C are state eq matrices for original system and slot variables A,B,C are used for error system matrices.
+     If initialize-queue-p is t, fill all queue by the first input at the begenning, otherwise, do not fill queue at the first."
     (setq orgA _orgA orgB _orgB orgC _orgC)
     (let* ((output-dim (array-dimension orgC 0))
            (org-state-dim (array-dimension orgA 0))
@@ -1380,30 +1408,28 @@
     )
   (:current-output-vector
    ()
+   "Current additional data value.
+    First value of additional-data-queue."
    (matrix-row xk* 0)
    )
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; preview-control class to compute reference COG from reference ZMP
+;;; COG (xy) trajectory generator using preview-control convert reference ZMP from reference COG
 ;;;  (refer to "Biped Walking Pattern Generation by using Preview Control of Zero-Moment Point", ICRA 2003, p.1620-1626, Shuuji KAJITA, Fumio KANEHIRO, Kenji KANEKO, Kiyoshi FUJIWARA, Kensuke HARADA, Kazuhito YOKOI and Hirohisa HIRUKAWA
 ;;;            "Humanoid Robot (in Japanese)", Ohmsha, 2005, Shuji Kajita, ISBN 4-274-20058-2)
-;;;  A, b, c -> system configuration matrices
-;;;  xk, uk  -> COG() and input for controller at "k"
-;;;             xk -> 3 x 2 matrix, uk -> 1 x 2 matrix (2 represents x and y)
-;;;  delay -> preview step calculated from predictive time (delay = N)
-;;;  p1-n -> reference ZMP queue (time is k, k+1, ... k+N)
-;;;  state equation of this system is
-;;;   xk+1 = A xk + b uk
-;;;   pk   = c xk
-;;;  unit system -> [mm], [s]
+;;; A,B,C -> Table-cart system
+;;; xk -> 3 x 2 matrix (3 = COG pos, vel, acc, 2 = x, y)
+;;; uk -> 1 x 2 matrix (COG jark of x and y)
+;;  yk -> zmp
+;;; unit system -> [mm], [s]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-control-cogxy-trajectory-generator
   :super propertied-object
   :slots (pc cog-z zmp-z))
 (defmethod preview-control-cogxy-trajectory-generator
   (:init
-    (dt _zc ;; dt -> sampling time[s], _zc is height of COG[mm]
+    (dt _zc
      &key (q 1) (r 1e-6)
           ((:delay d) 1.6)
           (init-xk (float-vector 0 0 0))
@@ -1415,7 +1441,11 @@
                                           (list dt))))
           ((:C _C) (make-matrix 1 3 (list (list 1.0 0.0 (- (/ _zc (elt *g-vec* 2)))))))
           ((:initialize-queue-p iqp))
-          (preview-controller-class preview-controller))
+          (preview-controller-class extended-preview-controller))
+    "COG (xy) trajectory generator using preview-control convert reference ZMP from reference COG.
+     dt -> sampling time[s], _zc is height of COG [mm].
+     preview-controller-class is preview controller class (extended-preview-controller by default).
+     For other arguments, please see preview-controller and extended-preview-controller :init documentation."
     (setq pc (instance preview-controller-class
                        :init dt :q q :r r :delay d
                        :init-xk init-xk :dim 2
@@ -1425,25 +1455,32 @@
   ;; getter methods
   (:refcog
    ()
+   "Reference COG [mm]."
    (let ((cv (send pc :current-state-vector)))
      (float-vector (elt cv 0) (elt cv 1) cog-z)))
-  (:cart-zmp () ;; table-cart zmp as an output variable
+  (:cart-zmp ()
+   "Cart-table system ZMP[mm] as an output variable."
     (let ((p (send pc :current-output-vector)))
       (float-vector (aref p 0 0)
                     (aref p 0 1)
                     zmp-z)))
   (:last-refzmp ()
-    (let ((p (send pc :last-reference-output-vector))) ;; tail of refzmp queue
+   "Reference zmp at the last of queue."
+    (let ((p (send pc :last-reference-output-vector)))
       (float-vector (elt p 0)
                     (elt p 1)
                     zmp-z)))
   (:current-refzmp ()
+   "Current reference zmp at the first of queue."
     (let ((p (send pc :current-reference-output-vector))) ;; head of refzmp queue
       (float-vector (elt p 0)
                     (elt p 1)
                     zmp-z)))
   ;;
-  (:update-xk (p &optional (add-data))
+  (:update-xk
+   (p &optional (add-data))
+   "Update xk and returns zmp and cog values.
+    For arguments, please see preview-controller and extended-preview-controller :update-xk."
     (if p (setq zmp-z (elt p 2)))
     (let ((ret (send pc :update-xk p add-data)))
       (if ret
@@ -1451,10 +1488,11 @@
            (send self :current-refzmp)
            (send self :refcog)
            (send self :cart-zmp)))))
-  (:finishedp () (send pc :finishedp))
-  (:current-additional-data () (send pc :current-additional-data))
+  (:finishedp () "Finished or not." (send pc :finishedp))
+  (:current-additional-data () "Current additional data value." (send pc :current-additional-data))
   (:pass-preview-controller
    (reference-output-vector-list)
+   "Get preview controller results from reference-output-vector-list and returns list."
    (let ((r) (ret))
      ;; Wait until initialize
      (while (not (setq r (send self :update-xk (pop reference-output-vector-list) nil))))
@@ -1464,7 +1502,7 @@
        (push r ret))
      (reverse ret)
      ))
-  (:cog-z () cog-z)
+  (:cog-z () "COG Z [mm]." cog-z)
   (:update-cog-z (zc)
     (setf (aref (pc . c) 0 2) (- (/ zc (elt *g-vec* 2))))
     (send pc :solve)

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1065,7 +1065,7 @@
              (send self :angle-vector (cadr (memq :angle-vector av)))
              (send self :move-coords (cadr (memq :root-coords av)) (car (send self :links)))))
      (update-robot-state (car avs))
-     (let ((df (instance preview-control-cogxy-trajectory-generator
+     (let ((df (instance preview-control-cart-table-cog-trajectory-generator
                          :init dt (elt (send self :centroid) 2) :delay delay :initialize-queue-p t
                          :preview-controller-class preview-controller-class))
            (r))
@@ -1418,16 +1418,16 @@
 ;;; COG (xy) trajectory generator using preview-control convert reference ZMP from reference COG
 ;;;  (refer to "Biped Walking Pattern Generation by using Preview Control of Zero-Moment Point", ICRA 2003, p.1620-1626, Shuuji KAJITA, Fumio KANEHIRO, Kenji KANEKO, Kiyoshi FUJIWARA, Kensuke HARADA, Kazuhito YOKOI and Hirohisa HIRUKAWA
 ;;;            "Humanoid Robot (in Japanese)", Ohmsha, 2005, Shuji Kajita, ISBN 4-274-20058-2)
-;;; A,B,C -> Table-cart system
+;;; A,B,C -> cart-table system
 ;;; xk -> 3 x 2 matrix (3 = COG pos, vel, acc, 2 = x, y)
 ;;; uk -> 1 x 2 matrix (COG jark of x and y)
 ;;  yk -> zmp
 ;;; unit system -> [mm], [s]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defclass preview-control-cogxy-trajectory-generator
+(defclass preview-control-cart-table-cog-trajectory-generator
   :super propertied-object
   :slots (pc cog-z zmp-z))
-(defmethod preview-control-cogxy-trajectory-generator
+(defmethod preview-control-cart-table-cog-trajectory-generator
   (:init
     (dt _zc
      &key (q 1) (r 1e-6)
@@ -1652,7 +1652,7 @@
     (send self :append-step-height-list 0.0)
     (pop footstep-node-list)
     ;; currently, not error system
-    (setq apreview-controller (instance preview-control-cogxy-trajectory-generator :init
+    (setq apreview-controller (instance preview-control-cart-table-cog-trajectory-generator :init
                                        dt (- (elt cog 2) (elt (car refzmp-cur-list) 2))
                                        :delay delay
                                        :q q :r r

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1196,7 +1196,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-controller-base
   :super riccati-equation
-  :slots (xk uk delay f1-n y1-n dim queue-index initialize-queue-p))
+  :slots (xk uk delay f1-n y1-n dim queue-index initialize-queue-p additional-data-queue))
 (defmethod preview-controller-base
   (:init
     (dt ; dt -> sampling time[s]
@@ -1235,21 +1235,30 @@
   (:calc-xk () ;; update xk+1
     (setq xk (m+ (m* A xk) (m* b (send self :calc-u)))))
   ;;
-  (:update-xk (p)
+  (:update-xk (p &optional (add-data))
     ;; update y1-n
     (if initialize-queue-p
         (when (null y1-n)
           (setq y1-n (make-matrix (1+ delay) dim))
-          (dotimes (i (1+ delay)) (setf (matrix-row y1-n i) (subseq p 0 dim))))
+          (setq additional-data-queue (make-list (1+ delay)))
+          (dotimes (i (1+ delay))
+            (setf (matrix-row y1-n i) (subseq p 0 dim))
+            (setf (elt additional-data-queue i) add-data)
+            ))
       (progn
         (when (null y1-n)
-          (setq y1-n (make-matrix (1+ delay) dim)))
+          (setq y1-n (make-matrix (1+ delay) dim))
+          (setq additional-data-queue (make-list (1+ delay))))
         (when (< queue-index (1+ delay))
           (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
+          (setf (elt additional-data-queue queue-index) add-data)
           (incf queue-index)
           (return-from :update-xk nil))))
-    (dotimes (i delay) (setf (matrix-row y1-n i) (matrix-row y1-n (1+ i))))
+    (dotimes (i delay)
+      (setf (matrix-row y1-n i) (matrix-row y1-n (1+ i)))
+      (setf (elt additional-data-queue i) (elt additional-data-queue (1+ i))))
     (setf (matrix-row y1-n delay) (subseq p 0 dim))
+    (setf (elt additional-data-queue delay) add-data)
     ;;
     (send self :calc-xk))
   (:last-reference-output-vector
@@ -1264,6 +1273,10 @@
   (:current-output-vector
    ()
    (m* c xk))
+  (:current-additional-data
+   ()
+   (car additional-data-queue)
+   )
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1403,9 +1416,9 @@
                     (elt p 1)
                     zmp-z)))
   ;;
-  (:update-xk (p)
+  (:update-xk (p &optional (add-data))
     (setq zmp-z (elt p 2))
-    (send-super :update-xk p))
+    (send-super :update-xk p add-data))
   (:cog-z () cog-z)
   (:update-cog-z (zc)
     (setf (aref c 0 2) (- (/ zc (elt *g-vec* 2))))
@@ -1500,35 +1513,33 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-dynamics-filter
   :super propertied-object
-  :slots (avs counter finishedp preview-controller))
+  :slots (counter finishedp preview-controller))
 
 (defmethod preview-dynamics-filter
   (:init (dt zc &optional (preview-class preview-control)
                 &rest args)
     (setq counter 0
           finishedp nil
-          preview-controller (instance* preview-class :init dt zc args)
-          avs (make-list (1+ (send preview-controller :delay))))
+          preview-controller (instance* preview-class :init dt zc args))
     self)
   ;;
   (:finishedp () finishedp)
-  (:av () (car avs)) ;; get parameters at "k"
+  (:av () (send preview-controller :current-additional-data)) ;; get parameters at "k"
   (:cart-zmp () (send preview-controller :cart-zmp))
   (:refcog () (send preview-controller :refcog))
   (:cog-z () (send preview-controller :cog-z))
   ;;
   (:update (av p)
     (let (r)
-      (dotimes (i (send preview-controller :delay)) (setf (elt avs i) (elt avs (1+ i))))
-      (setf (elt avs (send preview-controller :delay)) av)
       (cond (p
-	     (send preview-controller :update-xk p)
+	     (send preview-controller :update-xk p av)
 	     (if (< counter (send preview-controller :delay)) 	     
 		 (incf counter)
 	       (setq r t)))
 	    (t ;; (null p)
 	     (send preview-controller :update-xk
-                   (send preview-controller :last-refzmp))
+                   (send preview-controller :last-refzmp)
+                   av)
 	     (if (> counter 0) (setq r (decf counter)))))
       (if (<= counter 0) (setq finishedp t))
       (if r (cons (send preview-controller :current-refzmp)

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1289,12 +1289,12 @@
    finishedp)
   (:last-reference-output-vector
    ()
-   "Last value of reference output queue vector (y_{k+N}^{ref}).
+   "Last value of reference output queue vector (y_k+N_ref).
     Last value is latest future value."
    (matrix-row y1-n delay)) ;; tail of queue
   (:current-reference-output-vector
    ()
-   "First value of reference output queue vector (y_k^{ref}).
+   "First value of reference output queue vector (y_k_ref).
     First value is oldest future value and it can be used as current reference value."
    (matrix-row y1-n 0)) ;; head of queue
   (:current-state-vector

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1056,7 +1056,7 @@
   (:preview-control-dynamics-filter
    (dt ;; [s]
     avs ;; input motion : (list (list :angle-vector av :root-coords rc) ....)
-    &key (preview-class preview-control)
+    &key (preview-controller-class preview-controller)
          (cog-method :move-base-pos)
          (delay 0.8)) ;; [s]
    ;; generate av-list
@@ -1065,9 +1065,9 @@
              (send self :angle-vector (cadr (memq :angle-vector av)))
              (send self :move-coords (cadr (memq :root-coords av)) (car (send self :links)))))
      (update-robot-state (car avs))
-     (let ((df (instance preview-control
+     (let ((df (instance preview-control-cogxy-trajectory-generator
                          :init dt (elt (send self :centroid) 2) :delay delay :initialize-queue-p t
-                         :preview-controller-class preview-class))
+                         :preview-controller-class preview-controller-class))
            (r))
        (dotimes (i 2) (send self :calc-zmp))
        (let ((ret-list) (last-av) (ret-avs) (last-zmp) (av)
@@ -1195,10 +1195,10 @@
 ;;;   xk+1 = A xk + b uk
 ;;;   yk   = c xk
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defclass preview-controller-base
+(defclass preview-controller
   :super riccati-equation
   :slots (xk uk delay f1-n y1-n dim queue-index initialize-queue-p additional-data-queue finishedp initialized-p))
-(defmethod preview-controller-base
+(defmethod preview-controller
   (:init
     (dt ; dt -> sampling time[s]
      &key (q) (r)
@@ -1302,11 +1302,11 @@
 ;;;   xk+1* = A xk* + b duk
 ;;;   yk   = c xk*
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defclass extended-preview-controller-base
-  :super preview-controller-base
+(defclass extended-preview-controller
+  :super preview-controller
   :slots (orgA orgB orgC xk*))
 
-(defmethod extended-preview-controller-base
+(defmethod extended-preview-controller
   (:init
     (dt
      &key (q) (r) ((:delay d)) ((:dim tmp-dim))
@@ -1386,10 +1386,10 @@
 ;;;   pk   = c xk
 ;;;  unit system -> [mm], [s]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defclass preview-control
+(defclass preview-control-cogxy-trajectory-generator
   :super propertied-object
   :slots (pc cog-z zmp-z))
-(defmethod preview-control
+(defmethod preview-control-cogxy-trajectory-generator
   (:init
     (dt _zc ;; dt -> sampling time[s], _zc is height of COG[mm]
      &key (q 1) (r 1e-6)
@@ -1403,7 +1403,7 @@
                                           (list dt))))
           ((:C _C) (make-matrix 1 3 (list (list 1.0 0.0 (- (/ _zc (elt *g-vec* 2)))))))
           ((:initialize-queue-p iqp))
-          (preview-controller-class preview-controller-base))
+          (preview-controller-class preview-controller))
     (setq pc (instance preview-controller-class
                        :init dt :q q :r r :delay d
                        :init-xk init-xk :dim 2
@@ -1474,7 +1474,7 @@
           default-zmp-offsets ;; zmp offset list in the legs' end-coords ;; (list rleg-zmp-offset lleg-zmp-offset)
           finalize-p ;; Are all footstep-node-list executed? finalize flag for make-gait-parameter. Is this necessary?
           ;; preview controller parameters
-          preview-controller ;; preview controller for ZMP -> COG
+          apreview-controller ;; preview controller for ZMP -> COG
           all-limbs
           end-with-double-support
           ik-thre ;; position thre for ik
@@ -1590,12 +1590,12 @@
     (send self :append-step-height-list 0.0)
     (pop footstep-node-list)
     ;; currently, not error system
-    (setq preview-controller (instance preview-control :init
+    (setq apreview-controller (instance preview-control-cogxy-trajectory-generator :init
                                        dt (- (elt cog 2) (elt (car refzmp-cur-list) 2))
                                        :delay delay
                                        :q q :r r
                                        :init-xk cog
-                                       :preview-controller-class extended-preview-controller-base
+                                       :preview-controller-class extended-preview-controller
                                        )
           swing-leg-src-coords current-swing-leg-dst-coords
           refzmp-next (send self :get-limbs-zmp
@@ -1710,7 +1710,7 @@
                (limbs
                 (append (send self :get-counter-footstep-limbs (car support-leg-list))
                         (car support-leg-list))))
-           (+ (send preview-controller :cog-z)
+           (+ (send apreview-controller :cog-z)
               (elt (send self :get-limbs-zmp
                          (append swing-leg-proj-coords (car support-leg-coords-list))
                          limbs) 2))
@@ -1733,9 +1733,9 @@
     (let* ((preview-data ;; data to push to preview-controller's que
             (if support-leg-coords-list
                 (send self :calc-one-tick-gait-parameter type)))
-           (dd (send preview-controller :update-xk ;; return value from preview-controller
+           (dd (send apreview-controller :update-xk ;; return value from preview-controller
                      (if preview-data (elt preview-data 3)) preview-data))
-           (gp (send preview-controller :current-additional-data))) ;; gait parameter
+           (gp (send apreview-controller :current-additional-data))) ;; gait parameter
       (if dd (setf (elt (cdr dd) 2) (elt gp 4))) ;; overwrite 
       (let ((ret (if (and dd solve-angle-vector)
                      (append (send self :solve-angle-vector
@@ -1743,7 +1743,7 @@
                                    :solve-angle-vector solve-angle-vector
                                    :solve-angle-vector-args solve-angle-vector-args)
                              (if debug (append (butlast gp 2) (list (cdr dd)
-                                                                  (send preview-controller :cart-zmp))
+                                                                  (send apreview-controller :cart-zmp))
                                                (last gp)
                                                ))))))
         (when (>= 0 (decf index-count))

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1254,7 +1254,7 @@
     (send self :calc-xk))
   (:last-reference-output-vector
    ()
-   (matrix-row y1-n (1+ delay))) ;; tail of queue
+   (matrix-row y1-n delay)) ;; tail of queue
   (:current-reference-output-vector
    ()
    (matrix-row y1-n 0)) ;; head of queue
@@ -1383,21 +1383,22 @@
     (setq cog-z _zc)
     self)
   ;; getter methods
-  (:refcog () (float-vector (elt (matrix-row xk 0) 0)
-                            (elt (matrix-row xk 0) 1)
-                            cog-z))
-  (:cart-zmp (&optional (_c c)) ;; table-cart zmp as an output variable
-    (let ((p (m* _c xk)))
+  (:refcog
+   ()
+   (let ((cv (send self :current-state-vector)))
+     (float-vector (elt cv 0) (elt cv 1) cog-z)))
+  (:cart-zmp () ;; table-cart zmp as an output variable
+    (let ((p (send self :current-output-vector)))
       (float-vector (aref p 0 0)
                     (aref p 0 1)
                     zmp-z)))
   (:last-refzmp ()
-    (let ((p (matrix-row y1-n delay))) ;; tail of refzmp queue
+    (let ((p (send self :last-reference-output-vector))) ;; tail of refzmp queue
       (float-vector (elt p 0)
                     (elt p 1)
                     zmp-z)))
   (:current-refzmp ()
-    (let ((p (matrix-row y1-n 0))) ;; head of refzmp queue
+    (let ((p (send self :current-reference-output-vector))) ;; head of refzmp queue
       (float-vector (elt p 0)
                     (elt p 1)
                     zmp-z)))
@@ -1465,8 +1466,6 @@
       (setq xk* (make-matrix 4 dim))
       (setf (matrix-row xk* 0) (subseq init-xk 0 dim)))
     self)
-  ;; getter methods
-  (:cart-zmp () (send-super :cart-zmp orgc))
   ;;
   (:calc-f ()
     (setq f1-n (make-matrix 1 (1+ delay)))
@@ -1489,6 +1488,10 @@
             (v+ (matrix-row xk i)
                 (matrix-row xk* (1+ i)))))
     )
+  (:current-output-vector
+   ()
+   (matrix-row xk* 0)
+   )
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1291,6 +1291,17 @@
    ()
    (car additional-data-queue)
    )
+  (:pass-preview-controller
+   (reference-output-vector-list)
+   (let ((r) (ret))
+     ;; Wait until initialize
+     (while (not (setq r (send self :update-xk (pop reference-output-vector-list) nil))))
+     (push r ret)
+     ;; Get value until finish
+     (while (setq r (send self :update-xk (pop reference-output-vector-list) nil))
+       (push r ret))
+     (reverse ret)
+     ))
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1442,6 +1453,17 @@
            (send self :cart-zmp)))))
   (:finishedp () (send pc :finishedp))
   (:current-additional-data () (send pc :current-additional-data))
+  (:pass-preview-controller
+   (reference-output-vector-list)
+   (let ((r) (ret))
+     ;; Wait until initialize
+     (while (not (setq r (send self :update-xk (pop reference-output-vector-list) nil))))
+     (push r ret)
+     ;; Get value until finish
+     (while (setq r (send self :update-xk (pop reference-output-vector-list) nil))
+       (push r ret))
+     (reverse ret)
+     ))
   (:cog-z () cog-z)
   (:update-cog-z (zc)
     (setf (aref (pc . c) 0 2) (- (/ zc (elt *g-vec* 2))))

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1239,22 +1239,22 @@
     ;; initialize
     (if p
         (progn
-      (unless initialized-p
-        (incf queue-index)
-        (setq initialized-p (>= queue-index (1+ delay))))
-      (when (null y1-n)
-        (setq y1-n (make-matrix (1+ delay) dim))
-        (setq additional-data-queue (make-list (1+ delay)))
-        (if initialize-queue-p
-            (dotimes (i (1+ delay))
-              (setf (matrix-row y1-n i) (subseq p 0 dim))
-              (setf (elt additional-data-queue i) add-data)))
-        )
-      (unless initialize-queue-p
-        (when (< queue-index (1+ delay))
-          (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
-          (setf (elt additional-data-queue queue-index) add-data)
-          (return-from :update-xk nil))))
+          (unless initialized-p
+            (incf queue-index)
+            (setq initialized-p (>= queue-index (1+ delay))))
+          (when (null y1-n)
+            (setq y1-n (make-matrix (1+ delay) dim))
+            (setq additional-data-queue (make-list (1+ delay)))
+            (if initialize-queue-p
+                (dotimes (i (1+ delay))
+                  (setf (matrix-row y1-n i) (subseq p 0 dim))
+                  (setf (elt additional-data-queue i) add-data)))
+            )
+          (unless initialize-queue-p
+            (when (< queue-index (1+ delay))
+              (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
+              (setf (elt additional-data-queue queue-index) add-data)
+              (return-from :update-xk nil))))
       (progn
         (decf queue-index)
         (setq p (send self :last-reference-output-vector))

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1066,7 +1066,7 @@
              (send self :move-coords (cadr (memq :root-coords av)) (car (send self :links)))))
      (update-robot-state (car avs))
      (let ((df (instance preview-dynamics-filter
-                         :init dt (elt (send self :centroid) 2) preview-class :delay delay))
+                         :init dt (elt (send self :centroid) 2) preview-class :delay delay :initialize-queue-p t))
            (r))
        (dotimes (i 2) (send self :calc-zmp))
        (let ((ret-list) (last-av) (ret-avs) (last-zmp) (av)
@@ -1196,7 +1196,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-controller-base
   :super riccati-equation
-  :slots (xk uk delay f1-n y1-n dim queue-index))
+  :slots (xk uk delay f1-n y1-n dim queue-index initialize-queue-p))
 (defmethod preview-controller-base
   (:init
     (dt ; dt -> sampling time[s]
@@ -1207,8 +1207,9 @@
           ((:A _A))
           ((:B _B))
           ((:C _C))
-          (state-dim (array-dimension _A 0)))
-    (setq delay (round (/ d dt)) dim tmp-dim)
+          (state-dim (array-dimension _A 0))
+          ((:initialize-queue-p iqp)))
+    (setq delay (round (/ d dt)) dim tmp-dim initialize-queue-p iqp)
     (send-super :init _A _B _C q r)
     (setq queue-index 0)
     (when (null xk)
@@ -1236,12 +1237,17 @@
   ;;
   (:update-xk (p)
     ;; update y1-n
-    (when (null y1-n)
-      (setq y1-n (make-matrix (1+ delay) dim)))
-    (when (< queue-index (1+ delay))
-      (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
-      (incf queue-index)
-      (return-from :update-xk nil))
+    (if initialize-queue-p
+        (when (null y1-n)
+          (setq y1-n (make-matrix (1+ delay) dim))
+          (dotimes (i (1+ delay)) (setf (matrix-row y1-n i) (subseq p 0 dim))))
+      (progn
+        (when (null y1-n)
+          (setq y1-n (make-matrix (1+ delay) dim)))
+        (when (< queue-index (1+ delay))
+          (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
+          (incf queue-index)
+          (return-from :update-xk nil))))
     (dotimes (i delay) (setf (matrix-row y1-n i) (matrix-row y1-n (1+ i))))
     (setf (matrix-row y1-n delay) (subseq p 0 dim))
     ;;
@@ -1280,7 +1286,8 @@
      &key (q) (r) ((:delay d)) ((:dim tmp-dim))
           (init-xk (float-vector 0 0 0))
           ((:A _orgA)) ((:B _orgB)) ((:C _orgC))
-          (state-dim (array-dimension _orgA 0)))
+          (state-dim (array-dimension _orgA 0))
+          ((:initialize-queue-p iqp)))
     (setq orgA _orgA orgB _orgB orgC _orgC)
     (let* ((output-dim (array-dimension orgC 0))
            (org-state-dim (array-dimension orgA 0))
@@ -1305,7 +1312,7 @@
       (send-super :init
                   dt
                   :A newA :b newb :c newC :dim tmp-dim :state-dim state-dim
-                  :q q :r r :delay d :init-xk init-xk)
+                  :q q :r r :delay d :init-xk init-xk :initialize-queue-p iqp)
       (when (null xk*)
         (setq xk* (make-matrix new-state-dim dim))
         (setf (matrix-row xk* 0) (subseq init-xk 0 dim))
@@ -1368,10 +1375,11 @@
           ((:B _B) (make-matrix 3 1 (list (list (* (/ 1.0 6.0) dt dt dt))
                                           (list (* 0.5 dt dt))
                                           (list dt))))
-          ((:C _C) (make-matrix 1 3 (list (list 1.0 0.0 (- (/ _zc (elt *g-vec* 2))))))))
+          ((:C _C) (make-matrix 1 3 (list (list 1.0 0.0 (- (/ _zc (elt *g-vec* 2)))))))
+          ((:initialize-queue-p iqp)))
     (send-super :init dt :q q :r r :delay d
                 :init-xk init-xk :dim 2
-                :A _A :B _B :C _C :state-dim 3)
+                :A _A :B _B :C _C :state-dim 3 :initialize-queue-p iqp)
     (setq cog-z _zc)
     self)
   ;; getter methods
@@ -1420,7 +1428,7 @@
 
 (defmethod extended-preview-control
   (:init
-    (dt zc &key (q 1.0) (r 1.0e-6) ((:delay d) 1.6) (init-xk (float-vector 0 0 0)))
+    (dt zc &key (q 1.0) (r 1.0e-6) ((:delay d) 1.6) (init-xk (float-vector 0 0 0)) ((:initialize-queue-p iqp)))
     (setq orgA (make-matrix 3 3 (list (list 1 dt (* 0.5 dt dt))
                                     (list 0 1 dt)
                                     (list 0 0 1)))
@@ -1452,7 +1460,7 @@
                   dt zc
                   :A newA :b newb
                   :c (make-matrix 1 4 (list (list 1.0 0.0 0.0 0.0)))
-                  :q q :r r :delay d :init-xk init-xk))
+                  :q q :r r :delay d :init-xk init-xk :initialize-queue-p iqp))
     (when (null xk*)
       (setq xk* (make-matrix 4 dim))
       (setf (matrix-row xk* 0) (subseq init-xk 0 dim)))

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1270,8 +1270,9 @@
     (send self :calc-xk)
     ;; return
     (if (and initialized-p (not finishedp))
-        (cons (send self :current-reference-output-vector)
-              (send self :current-state-vector)))
+        (list (send self :current-reference-output-vector)
+              (send self :current-state-vector)
+              (send self :current-output-vector)))
     )
   (:finishedp () finishedp)
   (:last-reference-output-vector
@@ -1435,9 +1436,10 @@
     (if p (setq zmp-z (elt p 2)))
     (let ((ret (send pc :update-xk p add-data)))
       (if ret
-          (cons
+          (list
            (send self :current-refzmp)
-           (send self :refcog)))))
+           (send self :refcog)
+           (send self :cart-zmp)))))
   (:finishedp () (send pc :finishedp))
   (:current-additional-data () (send pc :current-additional-data))
   (:cog-z () cog-z)
@@ -1736,13 +1738,13 @@
            (dd (send apreview-controller :update-xk ;; return value from preview-controller
                      (if preview-data (elt preview-data 3)) preview-data))
            (gp (send apreview-controller :current-additional-data))) ;; gait parameter
-      (if dd (setf (elt (cdr dd) 2) (elt gp 4))) ;; overwrite 
+      (if dd (setf (elt (cadr dd) 2) (elt gp 4))) ;; overwrite 
       (let ((ret (if (and dd solve-angle-vector)
                      (append (send self :solve-angle-vector
-                                   (elt gp 0) (elt gp 1) (elt gp 2) (cdr dd)
+                                   (elt gp 0) (elt gp 1) (elt gp 2) (cadr dd)
                                    :solve-angle-vector solve-angle-vector
                                    :solve-angle-vector-args solve-angle-vector-args)
-                             (if debug (append (butlast gp 2) (list (cdr dd)
+                             (if debug (append (butlast gp 2) (list (cadr dd)
                                                                   (send apreview-controller :cart-zmp))
                                                (last gp)
                                                ))))))

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1256,8 +1256,87 @@
    ()
    (matrix-row xk 0))
   (:current-output-vector
-   (&optional (_c c))
-   (m* _c xk))
+   ()
+   (m* c xk))
+  )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; extended-preview-control class
+;;;  this class is error system of preview-control class
+;;;  (refer to "Digital Preview Control (in Japanese)", SangyoToshoKabusikiGaisha, Takeshi Tsuchiya and Tadashi Egami)
+;;;  orgA, orgb, orgc -> system configuration matrices for original table-cart model
+;;;  xk* -> [y_k^T, dxk^T]^T
+;;;  state equation of this system is
+;;;   xk+1* = A xk* + b duk
+;;;   yk   = c xk*
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defclass extended-preview-controller-base
+  :super preview-controller-base
+  :slots (orgA orgB orgC xk*))
+
+(defmethod extended-preview-controller-base
+  (:init
+    (dt
+     &key (q) (r) ((:delay d)) ((:dim tmp-dim))
+          (init-xk (float-vector 0 0 0))
+          ((:A _orgA)) ((:B _orgB)) ((:C _orgC))
+          (state-dim (array-dimension _orgA 0)))
+    (setq orgA _orgA orgB _orgB orgC _orgC)
+    (let* ((output-dim (array-dimension orgC 0))
+           (org-state-dim (array-dimension orgA 0))
+           (new-state-dim (+ output-dim org-state-dim))
+           (tmpcA (m* orgc orgA))
+           (newA (make-matrix new-state-dim new-state-dim))
+           (tmpcb (m* orgc orgB))
+           (newb (make-matrix new-state-dim (array-dimension orgB 1)))
+           (newC (make-matrix output-dim new-state-dim)))
+      (setf (aref newA 0 0) 1.0)
+      (dotimes (i output-dim)
+        (dotimes (j org-state-dim)
+          (setf (aref newA i (+ output-dim j)) (aref tmpcA i j))))
+      (dotimes (i org-state-dim)
+        (dotimes (j org-state-dim)
+          (setf (aref newA (+ 1 i) (+ 1 j)) (aref orgA i j))))
+      (setf (aref newb 0 0) (aref tmpcb 0 0))
+      (dotimes (i org-state-dim)
+        (setf (aref newb (+ output-dim i) 0) (aref orgb i 0)))
+      (dotimes (i output-dim)
+        (setf (aref newC i i) 1.0))
+      (send-super :init
+                  dt
+                  :A newA :b newb :c newC :dim tmp-dim :state-dim state-dim
+                  :q q :r r :delay d :init-xk init-xk)
+      (when (null xk*)
+        (setq xk* (make-matrix new-state-dim dim))
+        (setf (matrix-row xk* 0) (subseq init-xk 0 dim))
+        )
+      self))
+  ;;
+  (:calc-f ()
+    (setq f1-n (make-matrix 1 (1+ delay)))
+    (let* ((gsi (unit-matrix (array-dimension c 1)))
+	   (bt (transpose b))
+	   (ct (transpose c))
+	   (R+btPb-1bt (scale-matrix R+btPb-1 bt))
+	   (qt (scale-matrix Q ct)))
+      (dotimes (i delay)
+	(let* ((qt (if (= i (1- delay)) (m* P qt) qt))
+               (fa (scale-matrix R+btPb-1 (m* bt (m* gsi qt)))))
+          (setq gsi (m* A-bKt gsi))
+	  (setf (aref f1-n 0 (1+ i)) (aref fa 0 0))
+          ))))
+  (:calc-u () (m- (m* f1-n y1-n) (m* K xk*)))
+  (:calc-xk ()
+    (setq xk* (m+ (m* A xk*) (m* b (send self :calc-u))))
+    (dotimes (i (array-dimension orgA 0))
+      (setf (matrix-row xk i)
+            (v+ (matrix-row xk i)
+                (matrix-row xk* (1+ i)))))
+    )
+  (:current-output-vector
+   ()
+   (matrix-row xk* 0)
+   )
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1196,7 +1196,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-controller-base
   :super riccati-equation
-  :slots (xk uk delay f1-n y1-n dim queue-index initialize-queue-p additional-data-queue))
+  :slots (xk uk delay f1-n y1-n dim queue-index initialize-queue-p additional-data-queue finishedp initialized-p))
 (defmethod preview-controller-base
   (:init
     (dt ; dt -> sampling time[s]
@@ -1236,7 +1236,11 @@
     (setq xk (m+ (m* A xk) (m* b (send self :calc-u)))))
   ;;
   (:update-xk (p &optional (add-data))
-    ;; update y1-n
+    ;; initialize
+    (when p
+      (unless initialized-p
+        (incf queue-index)
+        (setq initialized-p (>= queue-index (1+ delay))))
     (if initialize-queue-p
         (when (null y1-n)
           (setq y1-n (make-matrix (1+ delay) dim))
@@ -1252,15 +1256,23 @@
         (when (< queue-index (1+ delay))
           (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
           (setf (elt additional-data-queue queue-index) add-data)
-          (incf queue-index)
-          (return-from :update-xk nil))))
+          (return-from :update-xk nil)))))
+    (unless p
+      (decf queue-index)
+      (setq p (send self :last-reference-output-vector))
+      (if (<= queue-index 0) (setq finishedp t)))
+    ;; update y1-n
     (dotimes (i delay)
       (setf (matrix-row y1-n i) (matrix-row y1-n (1+ i)))
       (setf (elt additional-data-queue i) (elt additional-data-queue (1+ i))))
     (setf (matrix-row y1-n delay) (subseq p 0 dim))
     (setf (elt additional-data-queue delay) add-data)
     ;;
-    (send self :calc-xk))
+    (send self :calc-xk)
+    (if (and initialized-p (not finishedp))
+        (cons (send self :current-reference-output-vector)
+              (send self :current-state-vector)))
+    )
   (:last-reference-output-vector
    ()
    (matrix-row y1-n delay)) ;; tail of queue
@@ -1417,7 +1429,7 @@
                     zmp-z)))
   ;;
   (:update-xk (p &optional (add-data))
-    (setq zmp-z (elt p 2))
+    (if p (setq zmp-z (elt p 2)))
     (send-super :update-xk p add-data))
   (:cog-z () cog-z)
   (:update-cog-z (zc)
@@ -1513,17 +1525,15 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-dynamics-filter
   :super propertied-object
-  :slots (counter finishedp preview-controller))
+  :slots (preview-controller))
 
 (defmethod preview-dynamics-filter
   (:init (dt zc &optional (preview-class preview-control)
                 &rest args)
-    (setq counter 0
-          finishedp nil
-          preview-controller (instance* preview-class :init dt zc args))
+    (setq preview-controller (instance* preview-class :init dt zc args))
     self)
   ;;
-  (:finishedp () finishedp)
+  (:finishedp () (preview-controller . finishedp))
   (:av () (send preview-controller :current-additional-data)) ;; get parameters at "k"
   (:cart-zmp () (send preview-controller :cart-zmp))
   (:refcog () (send preview-controller :refcog))
@@ -1531,19 +1541,11 @@
   ;;
   (:update (av p)
     (let (r)
-      (cond (p
-	     (send preview-controller :update-xk p av)
-	     (if (< counter (send preview-controller :delay)) 	     
-		 (incf counter)
-	       (setq r t)))
-	    (t ;; (null p)
-	     (send preview-controller :update-xk
-                   (send preview-controller :last-refzmp)
-                   av)
-	     (if (> counter 0) (setq r (decf counter)))))
-      (if (<= counter 0) (setq finishedp t))
-      (if r (cons (send preview-controller :current-refzmp)
-		  (send preview-controller :refcog)) nil)
+      (setq r (send preview-controller :update-xk p av))
+      (if r
+          (cons
+           (send preview-controller :current-refzmp)
+           (send preview-controller :refcog)))
       ))
   )
 

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1237,30 +1237,28 @@
   ;;
   (:update-xk (p &optional (add-data))
     ;; initialize
-    (when p
+    (if p
+        (progn
       (unless initialized-p
         (incf queue-index)
         (setq initialized-p (>= queue-index (1+ delay))))
-    (if initialize-queue-p
-        (when (null y1-n)
-          (setq y1-n (make-matrix (1+ delay) dim))
-          (setq additional-data-queue (make-list (1+ delay)))
-          (dotimes (i (1+ delay))
-            (setf (matrix-row y1-n i) (subseq p 0 dim))
-            (setf (elt additional-data-queue i) add-data)
-            ))
-      (progn
-        (when (null y1-n)
-          (setq y1-n (make-matrix (1+ delay) dim))
-          (setq additional-data-queue (make-list (1+ delay))))
+      (when (null y1-n)
+        (setq y1-n (make-matrix (1+ delay) dim))
+        (setq additional-data-queue (make-list (1+ delay)))
+        (if initialize-queue-p
+            (dotimes (i (1+ delay))
+              (setf (matrix-row y1-n i) (subseq p 0 dim))
+              (setf (elt additional-data-queue i) add-data)))
+        )
+      (unless initialize-queue-p
         (when (< queue-index (1+ delay))
           (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
           (setf (elt additional-data-queue queue-index) add-data)
-          (return-from :update-xk nil)))))
-    (unless p
-      (decf queue-index)
-      (setq p (send self :last-reference-output-vector))
-      (if (<= queue-index 0) (setq finishedp t)))
+          (return-from :update-xk nil))))
+      (progn
+        (decf queue-index)
+        (setq p (send self :last-reference-output-vector))
+        (if (<= queue-index 0) (setq finishedp t))))
     ;; update y1-n
     (dotimes (i delay)
       (setf (matrix-row y1-n i) (matrix-row y1-n (1+ i)))
@@ -1269,6 +1267,7 @@
     (setf (elt additional-data-queue delay) add-data)
     ;;
     (send self :calc-xk)
+    ;; return
     (if (and initialized-p (not finishedp))
         (cons (send self :current-reference-output-vector)
               (send self :current-state-vector)))

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1065,8 +1065,8 @@
              (send self :angle-vector (cadr (memq :angle-vector av)))
              (send self :move-coords (cadr (memq :root-coords av)) (car (send self :links)))))
      (update-robot-state (car avs))
-     (let ((df (instance preview-dynamics-filter
-                         :init dt (elt (send self :centroid) 2) preview-class :delay delay :initialize-queue-p t))
+     (let ((df (instance preview-class
+                         :init dt (elt (send self :centroid) 2) :delay delay :initialize-queue-p t))
            (r))
        (dotimes (i 2) (send self :calc-zmp))
        (let ((ret-list) (last-av) (ret-avs) (last-zmp) (av)
@@ -1085,12 +1085,12 @@
                   (rzmp (let ((tmp-zmp (cadr (memq :zmp av))))
                           (if tmp-zmp (setq last-zmp tmp-zmp) last-zmp)))
                   (dzmp (v- zmp rzmp)))
-             (setq r (send df :update (list av zmp (copy-object (send self :centroid)) rzmp) (if av dzmp nil)))
+             (setq r (send df :update-xk (if av dzmp nil) (list av zmp (copy-object (send self :centroid)) rzmp)))
              (when r
-               (push (list (send df :av) r) ret-list)
+               (push (list (send df :current-additional-data) r) ret-list)
                (let ((pav (send self :angle-vector))
                      (prc (send self :copy-worldcoords)))
-                 (update-robot-state (car (send df :av)))
+                 (update-robot-state (car (send df :current-additional-data)))
                  (case cog-method
                    (:move-centroid-on-foot
                     (send self :move-centroid-on-foot :both '(:lleg :rleg)
@@ -1272,6 +1272,7 @@
         (cons (send self :current-reference-output-vector)
               (send self :current-state-vector)))
     )
+  (:finishedp () finishedp)
   (:last-reference-output-vector
    ()
    (matrix-row y1-n delay)) ;; tail of queue
@@ -1429,7 +1430,11 @@
   ;;
   (:update-xk (p &optional (add-data))
     (if p (setq zmp-z (elt p 2)))
-    (send-super :update-xk p add-data))
+    (let ((ret (send-super :update-xk p add-data)))
+      (if ret
+          (cons
+           (send self :current-refzmp)
+           (send self :refcog)))))
   (:cog-z () cog-z)
   (:update-cog-z (zc)
     (setf (aref c 0 2) (- (/ zc (elt *g-vec* 2))))
@@ -1516,36 +1521,6 @@
    ()
    (matrix-row xk* 0)
    )
-  )
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; preview-dynamics-filter class to handle variables about preview control
-;;;  avs -> queue of variables for preview control (k, k+1, ..., k+N)
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defclass preview-dynamics-filter
-  :super propertied-object
-  :slots (preview-controller))
-
-(defmethod preview-dynamics-filter
-  (:init (dt zc &optional (preview-class preview-control)
-                &rest args)
-    (setq preview-controller (instance* preview-class :init dt zc args))
-    self)
-  ;;
-  (:finishedp () (preview-controller . finishedp))
-  (:av () (send preview-controller :current-additional-data)) ;; get parameters at "k"
-  (:cart-zmp () (send preview-controller :cart-zmp))
-  (:refcog () (send preview-controller :refcog))
-  (:cog-z () (send preview-controller :cog-z))
-  ;;
-  (:update (av p)
-    (let (r)
-      (setq r (send preview-controller :update-xk p av))
-      (if r
-          (cons
-           (send preview-controller :current-refzmp)
-           (send preview-controller :refcog)))
-      ))
   )
 
 ;;
@@ -1691,9 +1666,8 @@
     (send self :append-step-height-list 0.0)
     (pop footstep-node-list)
     ;; currently, not error system
-    (setq preview-controller (instance preview-dynamics-filter :init
+    (setq preview-controller (instance extended-preview-control :init
                                        dt (- (elt cog 2) (elt (car refzmp-cur-list) 2))
-                                       extended-preview-control
                                        :delay delay
                                        :q q :r r
                                        :init-xk cog
@@ -1834,9 +1808,9 @@
     (let* ((preview-data ;; data to push to preview-controller's que
             (if support-leg-coords-list
                 (send self :calc-one-tick-gait-parameter type)))
-           (dd (send preview-controller :update ;; return value from preview-controller
-                     preview-data (if preview-data (elt preview-data 3))))
-           (gp (send preview-controller :av))) ;; gait parameter
+           (dd (send preview-controller :update-xk ;; return value from preview-controller
+                     (if preview-data (elt preview-data 3)) preview-data))
+           (gp (send preview-controller :current-additional-data))) ;; gait parameter
       (if dd (setf (elt (cdr dd) 2) (elt gp 4))) ;; overwrite 
       (let ((ret (if (and dd solve-angle-vector)
                      (append (send self :solve-angle-vector

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1196,7 +1196,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-controller-base
   :super riccati-equation
-  :slots (xk uk delay f1-n y1-n dim))
+  :slots (xk uk delay f1-n y1-n dim queue-index))
 (defmethod preview-controller-base
   (:init
     (dt ; dt -> sampling time[s]
@@ -1210,6 +1210,7 @@
           (state-dim (array-dimension _A 0)))
     (setq delay (round (/ d dt)) dim tmp-dim)
     (send-super :init _A _B _C q r)
+    (setq queue-index 0)
     (when (null xk)
       (setq xk (make-matrix state-dim dim))
       (setf (matrix-row xk 0) (subseq init-xk 0 dim)))
@@ -1236,12 +1237,27 @@
   (:update-xk (p)
     ;; update y1-n
     (when (null y1-n)
-      (setq y1-n (make-matrix (1+ delay) dim))
-      (dotimes (i (1+ delay)) (setf (matrix-row y1-n i) (subseq p 0 dim))))
+      (setq y1-n (make-matrix (1+ delay) dim)))
+    (when (< queue-index (1+ delay))
+      (setf (matrix-row y1-n queue-index) (subseq p 0 dim))
+      (incf queue-index)
+      (return-from :update-xk nil))
     (dotimes (i delay) (setf (matrix-row y1-n i) (matrix-row y1-n (1+ i))))
     (setf (matrix-row y1-n delay) (subseq p 0 dim))
     ;;
     (send self :calc-xk))
+  (:last-reference-output-vector
+   ()
+   (matrix-row y1-n (1+ delay))) ;; tail of queue
+  (:current-reference-output-vector
+   ()
+   (matrix-row y1-n 0)) ;; head of queue
+  (:current-state-vector
+   ()
+   (matrix-row xk 0))
+  (:current-output-vector
+   (&optional (_c c))
+   (m* _c xk))
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1065,8 +1065,9 @@
              (send self :angle-vector (cadr (memq :angle-vector av)))
              (send self :move-coords (cadr (memq :root-coords av)) (car (send self :links)))))
      (update-robot-state (car avs))
-     (let ((df (instance preview-class
-                         :init dt (elt (send self :centroid) 2) :delay delay :initialize-queue-p t))
+     (let ((df (instance preview-control
+                         :init dt (elt (send self :centroid) 2) :delay delay :initialize-queue-p t
+                         :preview-controller-class preview-class))
            (r))
        (dotimes (i 2) (send self :calc-zmp))
        (let ((ret-list) (last-av) (ret-avs) (last-zmp) (av)
@@ -1386,8 +1387,8 @@
 ;;;  unit system -> [mm], [s]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defclass preview-control
-  :super preview-controller-base ;;riccati-equation
-  :slots (cog-z zmp-z))
+  :super propertied-object
+  :slots (pc cog-z zmp-z))
 (defmethod preview-control
   (:init
     (dt _zc ;; dt -> sampling time[s], _zc is height of COG[mm]
@@ -1401,126 +1402,49 @@
                                           (list (* 0.5 dt dt))
                                           (list dt))))
           ((:C _C) (make-matrix 1 3 (list (list 1.0 0.0 (- (/ _zc (elt *g-vec* 2)))))))
-          ((:initialize-queue-p iqp)))
-    (send-super :init dt :q q :r r :delay d
-                :init-xk init-xk :dim 2
-                :A _A :B _B :C _C :state-dim 3 :initialize-queue-p iqp)
+          ((:initialize-queue-p iqp))
+          (preview-controller-class preview-controller-base))
+    (setq pc (instance preview-controller-class
+                       :init dt :q q :r r :delay d
+                       :init-xk init-xk :dim 2
+                       :A _A :B _B :C _C :state-dim 3 :initialize-queue-p iqp))
     (setq cog-z _zc)
     self)
   ;; getter methods
   (:refcog
    ()
-   (let ((cv (send self :current-state-vector)))
+   (let ((cv (send pc :current-state-vector)))
      (float-vector (elt cv 0) (elt cv 1) cog-z)))
   (:cart-zmp () ;; table-cart zmp as an output variable
-    (let ((p (send self :current-output-vector)))
+    (let ((p (send pc :current-output-vector)))
       (float-vector (aref p 0 0)
                     (aref p 0 1)
                     zmp-z)))
   (:last-refzmp ()
-    (let ((p (send self :last-reference-output-vector))) ;; tail of refzmp queue
+    (let ((p (send pc :last-reference-output-vector))) ;; tail of refzmp queue
       (float-vector (elt p 0)
                     (elt p 1)
                     zmp-z)))
   (:current-refzmp ()
-    (let ((p (send self :current-reference-output-vector))) ;; head of refzmp queue
+    (let ((p (send pc :current-reference-output-vector))) ;; head of refzmp queue
       (float-vector (elt p 0)
                     (elt p 1)
                     zmp-z)))
   ;;
   (:update-xk (p &optional (add-data))
     (if p (setq zmp-z (elt p 2)))
-    (let ((ret (send-super :update-xk p add-data)))
+    (let ((ret (send pc :update-xk p add-data)))
       (if ret
           (cons
            (send self :current-refzmp)
            (send self :refcog)))))
+  (:finishedp () (send pc :finishedp))
+  (:current-additional-data () (send pc :current-additional-data))
   (:cog-z () cog-z)
   (:update-cog-z (zc)
-    (setf (aref c 0 2) (- (/ zc (elt *g-vec* 2))))
-    (send self :solve)
-    (send self :calc-f))
-  )
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; extended-preview-control class to compute reference COG from reference ZMP
-;;;  this class is error system of preview-control class
-;;;  (refer to "Digital Preview Control (in Japanese)", SangyoToshoKabusikiGaisha, Takeshi Tsuchiya and Tadashi Egami)
-;;;  orgA, orgb, orgc -> system configuration matrices for original table-cart model
-;;;  xk* -> [p^T, dxk^T]^T, (1+3) x 2 matrix
-;;;  state equation of this system is
-;;;   xk+1* = A xk* + b duk
-;;;   pk   = c xk*
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defclass extended-preview-control
-  :super preview-control
-  :slots (orgA orgB orgC xk*))
-
-(defmethod extended-preview-control
-  (:init
-    (dt zc &key (q 1.0) (r 1.0e-6) ((:delay d) 1.6) (init-xk (float-vector 0 0 0)) ((:initialize-queue-p iqp)))
-    (setq orgA (make-matrix 3 3 (list (list 1 dt (* 0.5 dt dt))
-                                    (list 0 1 dt)
-                                    (list 0 0 1)))
-          orgb (make-matrix 3 1 (list (list (* (/ 1.0 6.0) dt dt dt))
-                                    (list (* 0.5 dt dt))
-                                    (list dt)))
-          orgc (make-matrix 1 3 (list (list 1.0 0.0 (- (/ zc (elt *g-vec* 2)))))))
-    (let* ((tmpAc (m* orgc orgA))
-           (newA (make-matrix
-                  (+ 1 (cadr (array-dimensions tmpAc)))
-                  (+ 3 (car (array-dimensions tmpAc)))))
-           (tmpcb (m* orgc orgb))
-           (newb (make-matrix
-                  (+ 1 (car (array-dimensions orgb))) 1)))
-      (setf (aref newA 0 0) 1.0)
-      (dotimes (i (cadr (array-dimensions tmpAc)))
-        (setf (aref newA 0 (+ 1 i)) (aref tmpAc 0 i)))
-      (dotimes (i (car (array-dimensions orgA)))
-        (dotimes (j (cadr (array-dimensions orgA)))
-          (setf (aref newA (+ 1 i) (+ 1 j)) (aref orgA i j))))
-      (setf (aref newb 0 0) (aref tmpcb 0 0))
-      (dotimes (i (car (array-dimensions orgb)))
-        (setf (aref newb (+ 1 i) 0) (aref orgb i 0)))
-      ;; (concatenate-matrix-column
-      ;;  (concatenate-matrix-row (make-matrix 1 1 (list (list 1.0))) (m* orgc orgA))
-      ;;  (concatenate-matrix-row (make-matrix 3 1 (list (list 0) (list 0) (list 0))) orgA))
-      ;; (concatenate-matrix-column (m* orgc orgb) orgb)
-      (send-super :init
-                  dt zc
-                  :A newA :b newb
-                  :c (make-matrix 1 4 (list (list 1.0 0.0 0.0 0.0)))
-                  :q q :r r :delay d :init-xk init-xk :initialize-queue-p iqp))
-    (when (null xk*)
-      (setq xk* (make-matrix 4 dim))
-      (setf (matrix-row xk* 0) (subseq init-xk 0 dim)))
-    self)
-  ;;
-  (:calc-f ()
-    (setq f1-n (make-matrix 1 (1+ delay)))
-    (let* ((gsi (unit-matrix (array-dimension c 1)))
-	   (bt (transpose b))
-	   (ct (transpose c))
-	   (R+btPb-1bt (scale-matrix R+btPb-1 bt))
-	   (qt (scale-matrix Q ct)))
-      (dotimes (i delay)
-	(let* ((qt (if (= i (1- delay)) (m* P qt) qt))
-               (fa (scale-matrix R+btPb-1 (m* bt (m* gsi qt)))))
-          (setq gsi (m* A-bKt gsi))
-	  (setf (aref f1-n 0 (1+ i)) (aref fa 0 0))
-          ))))
-  (:calc-u () (m- (m* f1-n y1-n) (m* K xk*)))
-  (:calc-xk ()
-    (setq xk* (m+ (m* A xk*) (m* b (send self :calc-u))))
-    (dotimes (i 3)
-      (setf (matrix-row xk i)
-            (v+ (matrix-row xk i)
-                (matrix-row xk* (1+ i)))))
-    )
-  (:current-output-vector
-   ()
-   (matrix-row xk* 0)
-   )
+    (setf (aref (pc . c) 0 2) (- (/ zc (elt *g-vec* 2))))
+    (send pc :solve)
+    (send pc :calc-f))
   )
 
 ;;
@@ -1666,11 +1590,12 @@
     (send self :append-step-height-list 0.0)
     (pop footstep-node-list)
     ;; currently, not error system
-    (setq preview-controller (instance extended-preview-control :init
+    (setq preview-controller (instance preview-control :init
                                        dt (- (elt cog 2) (elt (car refzmp-cur-list) 2))
                                        :delay delay
                                        :q q :r r
                                        :init-xk cog
+                                       :preview-controller-class extended-preview-controller-base
                                        )
           swing-leg-src-coords current-swing-leg-dst-coords
           refzmp-next (send self :get-limbs-zmp

--- a/irteus/test/irteus-demo.l
+++ b/irteus/test/irteus-demo.l
@@ -70,7 +70,7 @@
 
 (deftest test-test-extended-preview-control
   (assert
-   (every #'identity (test-preview-control :preview-class extended-preview-control))))
+   (every #'identity (test-preview-control :preview-controller-class extended-preview-controller))))
 
 (deftest test-test-preview-control-dynamics-filter-for-sample-robot
   (assert
@@ -78,7 +78,7 @@
 
 (deftest test-test-extended-preview-control-dynamics-filter-for-sample-robot
   (assert
-   (every #'identity (test-preview-control-dynamics-filter-for-sample-robot :preview-class extended-preview-control))))
+   (every #'identity (test-preview-control-dynamics-filter-for-sample-robot :preview-controller-class extended-preview-controller))))
 
 (deftest test-test-sample-1dof-closed-link-robot
   (assert

--- a/irteus/test/irteus-demo.l
+++ b/irteus/test/irteus-demo.l
@@ -64,13 +64,37 @@
           (mapcar #'(lambda (rs-list) (not (some #'null (mapcar #'(lambda (x) (cadr (memq :angle-vector x))) rs-list))))
                   (walk-motion-for-robots)))))
 
-(deftest test-test-preview-control
+(deftest test-test-preview-control-0
   (assert
-   (every #'identity (test-preview-control))))
+   (every #'identity (test-preview-control-0))))
 
-(deftest test-test-extended-preview-control
+(deftest test-test-extended-preview-control-0
   (assert
-   (every #'identity (test-preview-control :preview-controller-class extended-preview-controller))))
+   (every #'identity (test-preview-control-0 :preview-controller-class extended-preview-controller))))
+
+(deftest test-test-preview-control-1
+  (assert
+   (every #'identity (test-preview-control-1))))
+
+(deftest test-test-extended-preview-control-1
+  (assert
+   (every #'identity (test-preview-control-1 :preview-controller-class extended-preview-controller))))
+
+(deftest test-test-preview-control-2
+  (assert
+   (every #'identity (test-preview-control-2))))
+
+(deftest test-test-extended-preview-control-2
+  (assert
+   (every #'identity (test-preview-control-2 :preview-controller-class extended-preview-controller))))
+
+(deftest test-test-preview-control-3
+  (assert
+   (every #'identity (test-preview-control-3))))
+
+(deftest test-test-extended-preview-control-3
+  (assert
+   (every #'identity (test-preview-control-3 :preview-controller-class extended-preview-controller))))
 
 (deftest test-test-preview-control-dynamics-filter-for-sample-robot
   (assert


### PR DESCRIPTION
Refine preview controller class name and hierarchy.
- [previous] `preview-control` is too generic class name and actually only used for table-cart system model.
- [new] Add `preview-controller` classes for generic preview controller and add `preview-control-cart-table-cog-trajectory-generator` instead of old `preview-controller`. User can use generic `preview-controller` theory.

Remove `prevyew-dynamics-filter` class because it behaviour is similler to `preview-control` with queue.

Add new examples for long walk, linear zmp transition, and impulsive force like JSK-OB Kanzaki-san's work.

This PR changes class definitions and this is big change.
However, almost all users does not use preview-controller explicitly and use it through walking methods in `irtdyna.l` and `irtrobot.l`.
I did not change user interface for these walking methods, so almost all users are influenced by this PR change.