### PR TITLE
Modify support-polygon method to support convex hull of given name and add example to crank-motion

### DIFF
--- a/irteus/demo/crank-motion.l
+++ b/irteus/demo/crank-motion.l
@@ -106,6 +106,7 @@
                :dump-command nil)
          ;; draw
          (send *irtviewer* :draw-objects :flush nil)
+         (send (send *robot* :support-polygon '(:rleg :lleg)) :draw-on :flush nil :width 4)
          (mapcar #'(lambda (act ref)
                      (send act :draw-on :flush nil :size 100)
                      (send ref :draw-on :flush nil :color #f(1 0 0)))

--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -822,8 +822,17 @@
    support-polygons)
   (:support-polygon
    (name)
-   "Return support polygon with given name."
-   (find name (send self :support-polygons) :test #'equal :key #'(lambda (x) (send x :name))))
+   "Return support polygon.
+    If name is list, return convex hull of all polygons.
+    Otherwise, return polygon with given name"
+   (if (consp name)
+       (instance polygon :init :vertices (quickhull
+                                          (apply
+                                           #'append
+                                           (mapcar #'(lambda (nm)
+                                                       (send (send self :support-polygon nm) :vertices))
+                                                   name))))
+     (find name (send self :support-polygons) :test #'equal :key #'(lambda (x) (send x :name)))))
   (:make-support-polygons
    ()
    (setq support-polygons


### PR DESCRIPTION
Modify support-polygon method to support convex hull of given name and add example to crank-motion.

Usage:
```
(send *robot* :support-polygon :rleg)
(send *robot* :support-polygon :lleg)
(send *robot* :support-polygon '(:rleg :lleg)) ;; new
```

```
4.irteusgl$ load "demo/crank-motion.l 
(crank-motion) ;; for fullbody motion
t
5.irteusgl$ (crank-motion)
nil
6.irteusgl$ (send *irtviewer* :viewer :viewsurface :write-to-image-file "/tmp/crank-motion-support-polygon.jpg")
#P"/tmp/crank-motion-support-polygon.jpg"
```

![crank-motion-support-polygon](https://cloud.githubusercontent.com/assets/11606776/9598954/d1e73636-50ca-11e5-814a-4ea3529a4c18.jpg)


