### PR TITLE
Add :worldcoords method to line to objects in irtviewer

### DIFF
--- a/irteus/irtgeo.l
+++ b/irteus/irtgeo.l
@@ -40,6 +40,11 @@
 		 :rot (user::midrot p (send c1 :worldrot) (send c2 :worldrot)))
     ))
 
+(defmethod line
+  (:worldcoords ()
+    "Return a coordinates on the midpoint of the end points"
+    (make-coords :pos (midpoint 0.5 nvert pvert))))
+
 (defmethod coordinates
   (:axis (axis)
 	 (send self :rotate-vector


### PR DESCRIPTION
Add `:worldcoords` method for irtviewer.

```
2.irteusgl$ (objects (list (instance line :init :nvertex (float-vector 0 0 0) :pvertex (float-vector 100 0 100))))
/opt/ros/hydro/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: cannot find method :worldcoords in (objects (list (instance line :init :nvertex (float-vector 0 0 0) :pvertex (float-vector 100 0 100))))
```

By adding :worldcoords, you can object line instances