### PR TITLE
Add ik debug log.

### DIFF
--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -452,9 +452,13 @@
 		   :link-list link-list
 		   :translation-axis translation-axis args)
 	    args)
-     (send self :calc-vel-for-cog cog-gain translation-axis target-centroid-pos
-           :centroid-offset-func centroid-offset-func
-           :update-mass-properties nil)
+     (let ((cvel
+            (send self :calc-vel-for-cog cog-gain translation-axis target-centroid-pos
+                  :centroid-offset-func centroid-offset-func
+                  :update-mass-properties nil)))
+       (when (send self :get :ik-target-error)
+         (push cvel (cdr (assoc :centroid (send self :get :ik-target-error)))))
+       cvel)
      )
     )
   (:calc-vel-for-cog

--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2317,8 +2317,13 @@
                (and (memq dump-command '(:fail-only :fail-only-with-debug-log)) (not success)))
        (setq command-directory
 	     (format nil "/tmp/irtmodel-ik-~A" (unix::getpid))
-	     command-id
-	     (let ((lt (unix::localtime))) (substitute #\0 #\  (format nil "~A-~04d-~02d-~02d-~02d-~02d-~02d" (send (class self) :name) (+ 1900 (elt lt 5)) (+ 1 (elt lt 4)) (elt lt 3) (elt lt 2) (elt lt 1) (elt lt 0))))
+	     command-id ;; command-id including [robot name], [localtime], and [usec time]
+             (let ((lt (unix::localtime)) (gtd (cadr (unix::gettimeofday))))
+               (substitute #\0 #\  (format nil "~A-~04d-~02d-~02d-~02d-~02d-~02d-~A-~A-~A"
+                                           (send (class self) :name) ;; name
+                                           (+ 1900 (elt lt 5)) (+ 1 (elt lt 4)) (elt lt 3) (elt lt 2) (elt lt 1) (elt lt 0) ;; localtime
+                                           (subseq (format nil "~0,6d" gtd) 0 2) (subseq (format nil "~0,6d" gtd) 2 4) (subseq (format nil "~0,6d" gtd) 4) ;; usec
+                                           )))
              command-filename (format nil "~A/~A-~A.l" command-directory command-id (if success "success" "failure")))
        (unix::mkdir command-directory)
        (with-open-file

--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2052,6 +2052,8 @@
                    (* 1000.0 (norm vel-p)) (elt thre i) (norm vel-r) (elt rthre i)))
            (dotimes (j (length vel-p)) (setf (elt tmp-dim j) (* dif-pos-ratio (elt vel-p j))))
            (dotimes (j (length vel-r)) (setf (elt tmp-dim (+ j (length vel-p))) (* dif-rot-ratio (elt vel-r j))))
+           (when (send self :get :ik-target-error)
+             (push (list vel-p vel-r) (cdr (assoc (read-from-string (format nil ":target-~d" i)) (send self :get :ik-target-error)))))
            ))
        (dotimes (i (length tmp-dims))
          (dotimes (j (length (elt tmp-dims i)))
@@ -2072,7 +2074,10 @@
                           (send self :calc-vel-for-cog tmp-cog-gain cog-translation-axis target-centroid-pos
                                 :centroid-offset-func centroid-offset-func
                                 :update-mass-properties nil))
-                         additional-vel))))
+                         additional-vel))
+           (when (send self :get :ik-target-error)
+             (push (car additional-vel) (cdr (assoc :centroid (send self :get :ik-target-error)))))
+           ))
        ;; append additional-jacobi and additional-vel
        (let (add-vel-list (row0) add-vel add-jacobi)
          (when additional-jacobi
@@ -2092,6 +2097,9 @@
              (when (and debug-view (not (memq :no-message debug-view)))
                (format-array add-jacobi (format nil "add-J~a    :" i-add-jacobi))
                (format-array add-vel (format nil "add-v~a    :" i-add-jacobi)))
+             (when (send self :get :ik-target-error)
+               (if (and (not cog-null-space) target-centroid-pos (/= i-add-jacobi 0)) ;; First additional-vel is for COG, so neglect
+                   (push (car additional-vel) (cdr (assoc (read-from-string (format nil ":additional-~d" (- i-add-jacobi 1))) (send self :get :ik-target-error))))))
              )))
 
        ;; check loop end
@@ -2152,10 +2160,13 @@
                   (additional-jacobi) (additional-vel)
 		  &allow-other-keys)
    "Move move-target to target-coords.
-    dump-command should be t, nil, or :fail-only.
-      t          : dump log both in success and fail.
-      :fail-only : dump log only in fail.
-      nil        : do not dump log."
+    dump-command should be t, nil, :always, :fail-only, :always-with-debug-log, or :fail-only-with-debug-log.
+    Log are success/fail log and ik debug information log.
+      t or :always           : dump log both in success and fail (for success/fail log).
+      :always-with-debug-log : dump log both in success and fail (for success/fail log and ik debug information log).
+      :fail-only             : dump log only in fail (for success/fail log).
+      :always-with-debug-log : dump log only in fail (for success/fail log and ik debug information log).
+      nil                    : do not dump log."
    ;; target-coords, move-target, rotation-axis, translation-axis, link-list
    ;; -> both list and atom OK.
    (let* ((loop 0)
@@ -2235,6 +2246,14 @@
                                       (reduce #'+ (mapcar #'(lambda (aj) (array-dimension (if (functionp aj) (funcall aj link-list) aj) 0)) tmp-additional-jacobi)))
                                    :union-link-list union-link-list args) args)))
      (send self :reset-joint-angle-limit-weight-old union-link-list) ;; reset weight
+     (when (memq dump-command '(:always-with-debug-log :fail-only-with-debug-log))
+       ;; If ik debug information log is enabled, initialize empty list for ik target errors.
+       (send self :put :ik-target-error
+             (append
+              (let ((tmp-count -1)) (mapcar #'(lambda (x) (list (read-from-string (format nil ":target-~d" (incf tmp-count))))) (make-list (length target-coords)))) ;; For target-coords error
+              (if target-centroid-pos (list (list :centroid))) ;; For taget-centroid-pos error
+              (let ((tmp-count -1)) (mapcar #'(lambda (x) (list (read-from-string (format nil ":additional-~d" (incf tmp-count))))) (make-list (length additional-vel)))) ;; For additional-vel error
+              )))
      
      ;; inverse kinematics loop
      (while (< (incf loop) stop)
@@ -2294,8 +2313,8 @@
      (if check-collision (setq collision-status (send self :self-collision-check)))
      (setq success (and (or success (not revert-if-fail)) (not collision-status)))
      ;; Dump log
-     (when (or (eq dump-command t)
-               (and (eq dump-command :fail-only) (not success)))
+     (when (or (memq dump-command '(:always :always-with-debug-log t))
+               (and (memq dump-command '(:fail-only :fail-only-with-debug-log)) (not success)))
        (setq command-directory
 	     (format nil "/tmp/irtmodel-ik-~A" (unix::getpid))
 	     command-id
@@ -2307,7 +2326,19 @@
         (format f "~A" initial-log-str)
         (dump-structure f initial-target-coords)
         (dump-structure f initial-av)
-        ))
+        )
+       (if (memq dump-command '(:fail-only-with-debug-log :always-with-debug-log)) ;; For ik debug information log
+           (with-open-file
+            (f (format nil "~A/~A-~A-debug-log.l" command-directory command-id (if success "success" "failure")) :direction :output)
+            (format f "(setq *ik-loop* ~A~%" loop)
+            (format f "      *ik-target-error* '~A~%" (mapcar #'(lambda (x) (append (list (car x)) (reverse (cdr x)))) (send self :get :ik-target-error)))
+            (format f "      *ik-target-error-thre* '~A)~%"
+                    (append
+                     (let ((tmp-count -1)) (mapcar #'(lambda (tr rtr) (list (read-from-string (format nil ":target-~d" (incf tmp-count))) (list (* 1e-3 tr) rtr))) thre rthre)) ;; For target-coords threshold (thre[m], rthre[rad])
+                     (if target-centroid-pos (list (list :centroid (* 1e-3 centroid-thre)))))) ;; For target-centroid-pos threshold [m]
+            (remprop self :ik-target-error)
+            ))
+       )
      ;; check solved or not
      (if success
          (send self :angle-vector)

--- a/irteus/test/test-irt-motion.l
+++ b/irteus/test/test-irt-motion.l
@@ -6,6 +6,7 @@
 (load "irteus/demo/sample-robot-model.l")
 (load "irteus/demo/sample-arm-model.l")
 (load "irteus/demo/sample-multidof-arm-model.l")
+(load "irteus/demo/special-joints.l")
 (unless (boundp '*sample-robot*)
   (setq *sample-robot* (instance sample-robot :init))
   (unless (or (null x::*display*) (= x::*display* 0))
@@ -353,13 +354,15 @@
             (log-directory)
             (remove-if-not #'(lambda (x) (substringp (format nil "~A-" (send (class robot) :name)) x)) (directory log-directory))))
     (let* ((log-directory (format nil "/tmp/irtmodel-ik-~A" (unix::getpid)))
-           (prev-log-files (find-log-files log-directory)))
+           (prev-log-files))
+      (unix:system (format nil "rm -f ~A/*" log-directory)) ;; clear log file
+      (setq prev-log-files (find-log-files log-directory))
       (funcall ik-function robot)
       (let ((new-log-file ;; find latest log
              (car (remove-if #'(lambda (x) (member x prev-log-files :test #'string=)) (find-log-files log-directory)))))
         ;; ik log execution
         (progn (load (format nil "~A/~A" log-directory new-log-file))(ik-setup)(null-output (ik-check)))
-        (unix:system (format nil "rm -f ~A/~A" log-directory new-log-file)) ;; clear log file
+        (unix:system (format nil "rm -f ~A/*" log-directory)) ;; clear log file
         t))))
 
 (defun test-load-ik-fail-log-rarm-ik-common
@@ -434,6 +437,52 @@
       (unix:system (format nil "rm -f /tmp/irtmodel-ik-~A/*" (unix::getpid)))
       (reverse ret)
       )))
+
+(defun test-load-ik-debug-information-log-common
+  (dump-command &key (debug-view t))
+  (labels ((find-log-files
+            (log-directory robot)
+            (remove-if-not #'(lambda (x) (substringp (format nil "~A-" (send (class robot) :name)) x)) (directory log-directory))))
+    (let* ((robot (instance sample-legged-robot-with-interlocking-joints :init))
+           (log-directory (format nil "/tmp/irtmodel-ik-~A" (unix::getpid)))
+           (prev-log-files (find-log-files log-directory robot)))
+      (unix:system (format nil "rm -f ~A/*" log-directory)) ;; clear log file
+      ;; Initialize poses
+      (send robot :rleg :angle-vector #f(0.0 0.0 -40.0 40.0 40.0 -40.0 0.0))
+      (send robot :lleg :angle-vector #f(0.0 0.0 -40.0 40.0 40.0 -40.0 0.0))
+      (send robot :fix-leg-to-coords (make-coords))
+      ;; IK
+      (send robot :move-centroid-on-foot :both '(:rleg :lleg) :dump-command dump-command :target-centroid-pos (float-vector 20 0 0))
+      ;; Chceck log
+      (let* ((new-log-files (remove-if #'(lambda (x) (member x prev-log-files :test #'string=)) (find-log-files log-directory robot)))
+             (new-log-file ;; find latest log
+              (car new-log-files))
+             (ret t))
+        ;; ik log load
+        (when dump-command
+          (mapcar #'(lambda (lf) (load (format nil "~A/~A" log-directory lf))) new-log-files)
+          (when (eq dump-command :always-with-debug-log)
+            (setq ret (and (numberp *ik-loop*)
+                           (not (cdr (assoc :target-0 *ik-target-error*)))
+                           (not (cdr (assoc :target-1 *ik-target-error*)))
+                           (not (cdr (assoc :centroid *ik-target-error*)))
+                           (not (cdr (assoc :additional-0 *ik-target-error*)))))
+            ))
+        (if debug-view (format t ";; files ~A~%" new-log-files))
+        (prog1
+            (case
+             dump-command
+             ((t :always)
+              (and (not (find-if #'(lambda (x) (substringp "debug-log.l" x)) new-log-files))
+                   (find-if #'(lambda (x) (substringp "success.l" x)) new-log-files)))
+             (:always-with-debug-log
+              (and ret
+                   (find-if #'(lambda (x) (substringp "debug-log.l" x)) new-log-files)
+                   (find-if #'(lambda (x) (substringp "success.l" x)) new-log-files)))
+             (nil
+              (= (length new-log-files) 0))))
+        (unix:system (format nil "rm -f ~A/*" log-directory)) ;; clear log file
+        t))))
 
 ;; check torque calculation comparing methods to calculate ext-force and ext-moment and robot root-link configuration
 (defun draw-objects-torque
@@ -806,6 +855,10 @@
 
 (deftest test-ik-fail-log-with-dump-command-args-for-sample-robot
   (assert (every #'identity (test-ik-fail-log-with-dump-command-args-common *sample-robot*))))
+
+(deftest test-load-ik-debug-information-log
+  (assert (every #'identity
+                 (mapcar #'(lambda (dc) (test-load-ik-debug-information-log-common dc)) '(t :always :always-with-debug-log nil)))))
 
 (deftest test-all-for-arm-robot-static-1
   (assert


### PR DESCRIPTION
Add ik debug log such as max loop count and dif-pos or dif-rot transition:
https://github.com/euslisp/jskeus/issues/40

dump-command should be t, nil, :always, :fail-only, :always-with-debug-log, or :fail-only-with-debug-log. 
Log are success/fail log and ik debug information                                                         
- t or :always           : dump log both in success and fail (for success/fail log).                           
- :always-with-debug-log : dump log both in success and fail (for success/fail log and ik debug information log).
- :fail-only             : dump log only in fail (for success/fail log).
- :always-with-debug-log : dump log only in fail (for success/fail log and ik debug information log).
- nil                    : do not dump log.

Add ik debug log writing and add test codes.