### PR TITLE
Reduce default min-loop for :fullbody-inveser-kinematics and :inverse-kinematics-for-closed-loop-forward-kinematics

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2545,6 +2545,7 @@
          (move-joints-hook) (additional-weight-list)
          ;; closed loop params
          (constrained-joint-list) (constrained-joint-angle-list)
+         (min-loop 2) ;; 2 is minimum loop count
     &allow-other-keys)
    "Solve inverse-kinematics for closed loop forward kinematics.
     Move move-target to target-coords with link-list.
@@ -2571,6 +2572,7 @@
           :additional-weight-list
           (append additional-weight-list
                   (mapcar #'(lambda (jnt) (list (send jnt :child-link) 0.0)) constrained-joint-list))
+          :min-loop min-loop
           args)
    )
   (:calc-jacobian-for-interlocking-joints

--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -430,6 +430,7 @@
           (additional-weight-list)
           (joint-args nil)
           (cog-null-space t)
+          (min-loop 2) ;; 2 is minimum loop count
      &allow-other-keys)
     "fullbody inverse kinematics for legged robot.
      necessary args : target-coords, move-target, and link-list must include legs' (or leg's) parameters
@@ -442,6 +443,7 @@
             :move-target move-target :link-list link-list-with-robot-6dof
             :cog-gain cog-gain :centroid-thre centroid-thre :target-centroid-pos target-centroid-pos
             :cog-translation-axis cog-translation-axis :centroid-offset-func centroid-offset-func :cog-null-space cog-null-space
+            :min-loop min-loop
             :additional-weight-list
             (append
              additional-weight-list


### PR DESCRIPTION
Reduce default min-loop for :fullbody-inveser-kinematics and :inverse-kinematics-for-closed-loop-forward-kinematics.