### PR TITLE
[irteus/irtrobot.l] fix a step-count-method for y-axis in go-pos-para…

### DIFF
--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -821,7 +821,7 @@
                (val val-max)
                (1+ (round (floor (- (/ (abs val) val-max) 1e-5))))))
        (do-push-steps (max (calc-max-count xx xx-max)
-                           (calc-max-count yy yy-max)
+                           (- (* (calc-max-count yy yy-max) 2) 1)
                            (calc-max-count th th-max))
                       #'(lambda ()
                           (let ((ddx (if (> xx-max (abs (- dx xx))) (- xx dx) (* xx-max x-sign)))


### PR DESCRIPTION
…ms->footstep-list

``go-pos-params->footstep-list``のy方向の刻み計算が直感と反している気がします。
少なくともhrpsysの``go-pos``とは異なるようです。

```lisp
(load "package://hrpsys_ros_bridge_tutorials/euslisp/samplerobot-interface.l")
(setq *robot* (samplerobot))
(send *robot* :fix-leg-to-coords (make-coords))
(send *robot* :go-pos-params->footstep-list 0 400 0)
```

をしたときに、最初は両足の真ん中は``(make-coords :pos #f(0 0 0))``ですが、

```lisp
(#<coordinates #X6efffa8 :rleg  -3.888e-15 -90.0 4.879e-18 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6ed3b68 :lleg  -3.880e-15 225.0 -1.220e-17 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6e8b868 :rleg  -3.885e-15 45.0 -2.439e-18 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6e8c468 :lleg  -3.876e-15 360.0 -1.952e-17 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6e8ccc0 :rleg  -3.881e-15 180.0 -9.758e-18 / -2.712e-20 5.551e-17 -5.421e-20>)
```

となって、両足の真ん中が``(make-coords :pos #f(0 270 0))``で止まってしまいます。

このPRを入れると

```lisp
(#<coordinates #X6e049d0 :rleg  -3.888e-15 -90.0 4.879e-18 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6dfb598 :lleg  -3.880e-15 225.0 -1.220e-17 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6e07c28 :rleg  -3.885e-15 45.0 -2.439e-18 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6db69d0 :lleg  -3.876e-15 360.0 -1.952e-17 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6d5ac68 :rleg  -3.881e-15 180.0 -9.758e-18 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6e3cb38 :lleg  -3.872e-15 490.0 -2.656e-17 / -2.712e-20 5.551e-17 -5.421e-20> #<coordinates #X6e3ce20 :rleg  -3.877e-15 310.0 -1.681e-17 / -2.712e-20 5.551e-17 -5.421e-20>)
```

となって、両足の真ん中が``(make-coords :pos #f(0 400 0))``となります。