### PR TITLE
[test/robot-model-usage.l] add test for :ray and :screen-point of camera class of samplerobot

### DIFF
--- a/irteus/irtsensor.l
+++ b/irteus/irtsensor.l
@@ -104,7 +104,14 @@
                       :screen 1.0
                       args
                       ))
+     (send vwing :screen (/ (* viewdistance pw 0.5) 1) (/ (* viewdistance ph 0.5) 1))
      (send self :assoc vwing)
+     (send self :newprojection
+           (make-matrix 4 4
+                        (list (float-vector  1  0 (/ pw 2) 0) ;; f = 1, t  =0
+                              (float-vector  0  1 (/ ph 2) 0) ;;
+                              (float-vector  0  0  1  0)
+                              (float-vector  0  0  0  1))))
      self))
   (:create-viewer ()
    (unless (boundp '*irtviewer*) (make-irtviewer))

--- a/irteus/test/robot-model-usage.l
+++ b/irteus/test/robot-model-usage.l
@@ -101,6 +101,30 @@
     (assert (eps-v= obr (send obj :worldpos)) "check :ray and :screen-point")
     ))
 
+(deftest test-camera-ray-screen-point-2
+  (let (cam obj scp ray odp)
+
+    (setq cam (send *robot* :camera "left-camera"))
+    (setq obj (make-cube 10 10 10 :pos #f(300 130 400)))
+
+    ;;(objects (list cam obj))
+    (format t ";; camera location ~A~%" (send cam :worldpos))
+    (format t ";; object location ~A~%" obj)
+    (setq scp (send cam :screen-point (send obj :worldpos)))
+    (format t ";; screen point ~A~%" scp)
+    (setq ray (send cam :ray (elt scp 0) (elt scp 1)))
+    (format t ";; ray to the point ~A~%" ray)
+    ;; object position relative to camera
+    (setq obp (send cam :inverse-transform-vector (send obj :worldpos)))
+    (format t ";; object location wrt camera ~A~%" obp)
+    ;; object postition using ray
+    (setq obr (v+ (send cam :worldpos) (scale (norm obp) ray)))
+    (format t ";; object location from :ray ~A~%" obr)
+
+
+    (assert (eps-v= obr (send obj :worldpos)) "check :ray and :screen-point")
+    ))
+
 
 (run-all-tests)
 (exit)


### PR DESCRIPTION
https://github.com/euslisp/jskeus/pull/293/files
で，:screen-3d と :ray をチェックしていますが，これ，`make-camera-from-params` から作っているカメラだと動くけど，sample-robot のカメラでは動かないです．これでなおりますが，大丈夫かどうか．