### PR TITLE
Fix hidden line

### DIFF
--- a/irteus/irtgl.l
+++ b/irteus/irtgl.l
@@ -297,9 +297,12 @@
         (glEnable GL_CULL_FACE)
         (glCullFace GL_FRONT)
 
-        (mapc #'(lambda (aface)
-                  (draw-face aface nil nil))
-              (send abody :faces))
+        (dolist (aface (send abody :faces))
+          (glBegin GL_POLYGON)
+          (glNormal3fv (transform (transpose (send abody :worldrot)) (send aface :normal)))
+          (dolist (e (send aface :edges))
+            (glVertex3fv (send abody :inverse-transform-vector (send e :pvertex aface))))
+          (glEnd))
 
         (glDisable GL_CULL_FACE)
         (glDisable GL_POLYGON_OFFSET_FILL)

--- a/irteus/irtviewer.l
+++ b/irteus/irtviewer.l
@@ -286,13 +286,15 @@
   (:select-drawmode
    (mode)
    (when (not (eq mode drawmode))
-     (dolist (obj draw-things)
-       (setf (get obj :GL-DISPLAYLIST-ID) nil)
-       (case mode
-         (user::hid
-          (setf (get obj :gl-hiddenline) (list (cons nil t))))
-         (t
-          (setf (get obj :gl-hiddenline) nil)))))
+     (let ((glcon ((send self :viewer :viewsurface) . gl::glcon)))
+       (dolist (obj draw-things)
+         (gl::delete-displaylist-id (get obj :GL-DISPLAYLIST-ID))
+         (setf (get obj :GL-DISPLAYLIST-ID) nil)
+         (case mode
+           (user::hid
+            (setf (get obj :gl-hiddenline) (list (cons glcon t))))
+           (t
+            (setf (get obj :gl-hiddenline) nil))))))
    (setq drawmode mode)
    drawmode)
   (:flush () (if viewer (send viewer :viewsurface :glflush)))


### PR DESCRIPTION
This PR fixed code for displaying objects with hidden-line mode.

~~~
(send *irtviewer* :select-drawmode 'hid)
(send *irtviewer* :draw-objects)
~~~

you can change line width by this command.
~~~
(send *irtviewer* :viewer :viewsurface :line-width 3)
~~~

default mode
![irtviewer](https://cloud.githubusercontent.com/assets/2408164/11299604/794fe776-8fcb-11e5-99a0-d348c03069b1.png)

hidden line mode
![irtviewer_hid](https://cloud.githubusercontent.com/assets/2408164/11299608/7cbcb6dc-8fcb-11e5-95c1-b3f9f16f351c.png)