### PR TITLE
[proposal] Add class for single link model.

### DIFF
--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -1017,6 +1017,27 @@
          ))
      sbp))
   )
+
+;;;;;;;;;;;;;;;;
+;; Utilities for object model
+;;;;;;;;;;;;;;;;
+(defclass single-link-model
+  :super cascaded-link
+  :slots ()
+  )
+
+(defmethod single-link-model
+  (:init
+   (&key (name) ((:bodies bs)))
+   (prog1
+       (send-super :init :name name)
+     (setq links (list (instance bodyset-link :init (make-cascoords)
+                                 :bodies bs :name :root-link)))
+     (send self :assoc (car links))
+     (send self :init-ending)
+     ))
+  )
+
 (in-package "GEOMETRY")
 
 (provide :irtrobot "$Id$")


### PR DESCRIPTION
This PR is just a proposal to add class for single link model
(related with @furushchev dinner discussion).
This is originally from https://github.com/jsk-ros-pkg/jsk_demos/blob/master/jsk_2015_06_hrp_drc/drc_task_common/euslisp/drc-testbed-models.l#L9.

This is used for creating single rigid body object model.

In this PR, I added `single-link-model` class, but I think adding function to create single link model is another solution.

@furushchev 
FYI, in euslisp, robot models and object models should be defined as `cascaded-link` class (or its subclass).

* historical situation
Even if simple shape (like `make-cube`) and single rigid body object, 
it would be better to define it as `cascaded-link` instead of `body` or `bodyset` class.
In `euslib/rbrain`, object models were defined as both `robot-object` (old style object model class) and `body` or `bodyset` class.
It was very confusing.
Since used methods are quite different between `robot-object` and `body`, some codes for `robot-object` did not work for `body` and it was difficult to generalize codes.

* definition
In euslisp, `body`, `bodyset`, `faceset`, ... classes have geometric shape information.
`bodyset-link` class has shape information and mass information and this class corresponds to so cold `link` in robotics fields.
`cascaded-link` class includes `links`, `joints`, and some other semantic information and this class corresponds to `robot` and `object`.
So, it would be better to define object model as `cascaded-link` class.
The codes in this PR may be minimal codes to define `cascaded-link` class with single link.