### PR TITLE
Add test for zero setting for orientation of 6dof-joint and sphere-joint. 

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -427,26 +427,31 @@
     self)
   (:joint-angle
     (&optional v &key relative &allow-other-keys)
-    "return joint-angle if v is not set, if v is given, set joint angle. v is joint-angle vector by axis-angle representation, i.e (scale rotation-angle-from-default-coords[deg] axis-unit-vector)"
-    ;; v is anguler velocity [deg]
+    "return joint-angle if v is not set, if v is given, set joint angle.
+     v is joint-angle vector [deg] by axis-angle representation, i.e (scale rotation-angle-from-default-coords[deg] axis-unit-vector)"
     (when v
-      ;; if relative nil
-      ;; v is equivalent to orthogonal orientation matrix calculated from (send (send world-default-coords :transformation child-link) :worldrot)
-      (unless relative (setq joint-angle v))
-      (let* ((drot (matrix-exponent (map float-vector #'deg2rad joint-angle))))
-	(if relative
-	    ;; if relative t
-	    ;; v is calculated from difference-rotation or jacobian
-	    (let ((vec (map float-vector #'deg2rad v)))
-	      (unless (eps= (norm vec) 0.0 1e-20)
-		(m* (rotation-matrix (norm vec) (normalize-vector vec)) drot drot))))
-	;; min max check
-	(let* ((dr (map float-vector #'rad2deg (matrix-log drot))))
-	  (setq joint-angle (vmin (vmax dr min-angle) max-angle)))
-	;; update child-link
-	(send child-link :replace-coords default-coords)
-	(send child-link :transform
-	      (make-coords :rot (matrix-exponent (map float-vector #'deg2rad joint-angle))))))
+      ;; Update joint-angle
+      (cond
+       (relative
+        ;; if relative t
+        ;; v is axis-angle difference vector calculated from difference-rotation or jacobian
+        (let ((vec (map float-vector #'deg2rad v)))
+          (unless (eps= (norm vec) 0.0 1e-20)
+            ;; If vec is large, update joint-angle
+            (let ((drot (matrix-exponent (map float-vector #'deg2rad joint-angle))))
+              (m* (rotation-matrix (norm vec) (normalize-vector vec)) drot drot)
+              (setq joint-angle (map float-vector #'rad2deg (matrix-log drot))))
+            )))
+       (t
+        ;; if relative nil
+        ;; v is axis-angle equivalent to orthogonal orientation matrix calculated from (send (send world-default-coords :transformation child-link) :worldrot)
+        (setq joint-angle v)))
+      ;; min max check
+      (setq joint-angle (vmin (vmax joint-angle min-angle) max-angle))
+      ;; update child-link
+      (send child-link :replace-coords default-coords)
+      (send child-link :transform
+            (make-coords :rot (matrix-exponent (map float-vector #'deg2rad joint-angle)))))
     joint-angle)
   (:joint-angle-rpy ;; v and return-value -> [deg] and (float-vector yaw roll pitch)
     (&optional v &key relative)
@@ -569,29 +574,38 @@
     (&optional v &key relative &allow-other-keys) ;; v [mm] [deg]
     "Return joint-angle if v is not set, if v is given, set joint angle vector, which is 6D vector of 3D translation[mm] and 3D rotation[deg], i.e. (find-if #'(lambda (x) (eq (send (car x) :name) 'sphere-joint)) (documentation :joint-angle))"
     (when v
-      (let (dp drot)
-	;; translation
-	(setq dp (if relative
-		     (v+ (subseq joint-angle 0 3) (subseq v 0 3))
-		   (subseq v 0 3)))
-	(setq dp (vmin (vmax dp (subseq min-angle 0 3)) (subseq max-angle 0 3)))
-	;; rotation
-	(unless relative (dotimes (i 3) (setf (elt joint-angle (+ i 3)) (elt v (+ i 3)))))
-	(setq drot (matrix-exponent (map float-vector #'deg2rad (subseq joint-angle 3 6))))
-	(if relative
-	    (let ((vec (map float-vector #'deg2rad (subseq v 3 6))))
-	      (unless (eps= (norm vec) 0.0 1e-20)
-		(m* (rotation-matrix (norm vec) (normalize-vector vec)) drot drot))))
-	;; min max check
-	(let* ((dr (map float-vector #'rad2deg (matrix-log drot))))
-	  (setq dr (vmin (vmax dr (subseq min-angle 3 6)) (subseq max-angle 3 6)))
-	  (dotimes (i 3)
-	    (setf (elt joint-angle i) (elt dp i))
-	    (setf (elt joint-angle (+ i 3)) (elt dr i)))
-	  ;; update child-link
-	  (send child-link :replace-coords default-coords)
-	  (send child-link :transform
-		(make-coords :rot (matrix-exponent (map float-vector #'deg2rad dr)) :pos dp)))))
+      (let (joint-angle-pos joint-angle-rot)
+        ;; Update joint-angle
+        ;;   translation
+        (setq joint-angle-pos (if relative
+                                  (v+ (subseq joint-angle 0 3) (subseq v 0 3))
+                                (subseq v 0 3)))
+        ;;   rotation
+        (cond
+         (relative
+          ;; if relative t
+          ;; rotation part of v is axis-angle difference vector calculated from difference-rotation or jacobian
+          (let ((vec (map float-vector #'deg2rad (subseq v 3 6))))
+            (if (eps= (norm vec) 0.0 1e-20)
+                (setq joint-angle-rot (subseq joint-angle 3 6))
+              (let ((drot (matrix-exponent (map float-vector #'deg2rad (subseq joint-angle 3 6)))))
+                (m* (rotation-matrix (norm vec) (normalize-vector vec)) drot drot)
+                (setq joint-angle-rot (map float-vector #'rad2deg (matrix-log drot))))
+              )))
+         (t
+          ;; if relative nil
+          ;; rotation part of v is axis-angle equivalent to orthogonal orientation matrix calculated from (send (send world-default-coords :transfor
+          (setq joint-angle-rot (subseq v 3 6))
+          ))
+        (dotimes (i 3)
+          (setf (elt joint-angle i) (elt joint-angle-pos i))
+          (setf (elt joint-angle (+ i 3)) (elt joint-angle-rot i)))
+        ;; min max check
+        (setq joint-angle (vmin (vmax joint-angle min-angle) max-angle))
+        ;; update child-link
+        (send child-link :replace-coords default-coords)
+        (send child-link :transform
+              (make-coords :rot (matrix-exponent (map float-vector #'deg2rad joint-angle-rot)) :pos joint-angle-pos))))
     joint-angle)
   (:joint-angle-rpy ;; v and return-value -> [deg] and (float-vector yaw roll pitch)
     (&optional v &key relative)

--- a/irteus/test/test-irt-motion.l
+++ b/irteus/test/test-irt-motion.l
@@ -337,6 +337,32 @@
        ))
     (list max-dif-pos max-dif-rot)))
 
+(defun test-zero-orientation-of-joint-class-common
+  (joint-class)
+  "Check zero setting for orientation of 6dof-joint and sphere-joint.
+   If zero vector is set as :joint-angle :relative t, worldrot should not change."
+  ;; Initialize
+  (setq *robot* (instance sample-multidof-joint-robot :init :joint-class joint-class
+                          :child-init-coords (make-coords :pos #f(100 200 300) :rpy (list (deg2rad 10) (deg2rad 20) (deg2rad 30)))))
+  (unless (or (null x::*display*) (= x::*display* 0))
+    (objects (list *robot*)))
+  (if (= (length (send *robot* :angle-vector)) 3)
+      (send *robot* :angle-vector #f(15.1 -25.2 35.3))
+    (send *robot* :angle-vector #f(20.0 -30.0 40.0 15.1 -25.2 35.3)))
+  (let ((rot1) (rot2))
+    ;; Rot before :joint-angle :relative t setting
+    (setq rot1 (copy-object (send (send (car (send *robot* :joint-list)) :child-link) :worldrot)))
+    (send (car (send *robot* :joint-list)) :joint-angle (if (= (length (send *robot* :angle-vector)) 3)
+                                                            (float-vector 0 0 0)
+                                                          (float-vector 0 0 0 0 0 0))
+          :relative t)
+    ;; Rot after :joint-angle :relative t setting
+    (setq rot2 (copy-object (send (send (car (send *robot* :joint-list)) :child-link) :worldrot)))
+    ;;(print (array-entity (m- rot1 rot2)))
+    ;; rot1 and rot2 should be same, otherwise it is numerical error.
+    (eps= (norm (array-entity (m- rot1 rot2))) 0.0 1e-20)
+    ))
+
 ;; test :cog-convergence-check
 (defun test-cog-convergence-check-common
   (robot)
@@ -840,6 +866,12 @@
      (and
       (> 0.05 (elt ret 0))
       (> (deg2rad 1e-2) (elt ret 1))))))
+
+(deftest test-zero-orientation-of-joint-class
+  (assert
+   (test-zero-orientation-of-joint-class-common sphere-joint))
+  (assert
+   (test-zero-orientation-of-joint-class-common 6dof-joint)))
 
 (deftest test-load-ik-fail-log-rarm-ik-for-sample-robot
   (assert (test-load-ik-fail-log-rarm-ik-common *sample-robot*)))


### PR DESCRIPTION
Add test for zero setting for orientation of 6dof-joint and sphere-joint. 
If zero vector is set as :joint-angle :relative t, worldrot should not change.

Currently, worldrot change slightly (numerical error like `1e-17` on 64bit machine).
So this travis will fail.

Next I'll update this PR to fix the problem.