### PR TITLE
Update :calc-grasp-matrix

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2558,20 +2558,28 @@
 	     (push p cpairs)))
 	 ))
      cpairs))
-  ;; calc grasp matrix
-  ;;  -> grasp matrix is defined as
-  ;;   | E_3    0   E_3    0   ... |
-  ;;   | p1_hat E_3 p2_hat E_3 ... |
   (:calc-grasp-matrix
-   (contact-points &optional (ret (make-matrix 6 (* 6 (length contact-points))))) ;; contact-points [mm]
-   (let ((contact-matrices (mapcar #'(lambda (x) (outer-product-matrix (scale 1e-3 x))) contact-points)))
+   (contact-points
+    &key (ret (make-matrix 6 (* 6 (length contact-points))))
+         (contact-rots (mapcar #'(lambda (r) (unit-matrix 3)) contact-points)))
+   "Calc grasp matrix.
+      Grasp matrix is defined as
+       | E_3 0   E_3 0   ... |
+       | p1x E_3 p2x E_3 ... |
+    Arguments:
+      contact-points is list of contact points[mm].
+      contact-rots is list of contact coords rotation[rad].
+      If contact-rots is specified, grasp matrix as follow:
+       | R1    0  R2    0  ... |
+       | p1xR1 R1 p2xR2 R2 ... |"
+   (let* ((contact-matrices (mapcar #'(lambda (p r) (m* (outer-product-matrix (scale 1e-3 p)) r)) contact-points contact-rots)))
      (dotimes (c (length contact-points))
        (dotimes (i 3)
-	 (setf (aref ret i (+ (* c 6) i)) 1.0)
-	 (setf (aref ret (+ 3 i) (+ (* c 6) 3 i)) 1.0)
-	 (dotimes (j 3)
-	   (setf (aref ret (+ 3 i) (+ (* c 6) j)) (aref (elt contact-matrices c) i j))
-	   )))
+         (dotimes (j 3)
+           (setf (aref ret i (+ (* c 6) j)) (aref (elt contact-rots c) i j))
+           (setf (aref ret (+ 3 i) (+ (* c 6) 3 j)) (aref (elt contact-rots c) i j))
+           (setf (aref ret (+ 3 i) (+ (* c 6) j)) (aref (elt contact-matrices c) i j))
+           )))
      ret))
   ;; closed loop kinematics method
   (:inverse-kinematics-for-closed-loop-forward-kinematics

--- a/irteus/test/test-irt-motion.l
+++ b/irteus/test/test-irt-motion.l
@@ -958,5 +958,44 @@
     (assert (eps-v= sbp1 sbp2) "Check equality of sbp1 and sbp2")
     ))
 
+(deftest test-calc-grasp-matrix
+  (let* ((size (1+ (random 10)))
+         (contact-points (mapcar #'(lambda (x) (random-vector)) (make-list size)))
+         (contact-rots (mapcar #'(lambda (x) (rpy-matrix (deg2rad (- (random 180.0) 90.0)) (deg2rad (- (random 180.0) 90.0)) (deg2rad (- (random 180.0) 90.0))))
+                               (make-list size)))
+         (world-force-list (mapcar #'(lambda (x) (random-vector)) (make-list size)))
+         (world-moment-list (mapcar #'(lambda (x) (random-vector)) (make-list size)))
+         (local-force-list (mapcar #'(lambda (f r) (transform (transpose r) f)) world-force-list contact-rots))
+         (local-moment-list (mapcar #'(lambda (n r) (transform (transpose r) n)) world-moment-list contact-rots)))
+    (warn ";; test-grasp-matrix size = ~A~%" size)
+    (let ((ret1
+           ;; Direct calculation
+           (concatenate float-vector
+                        (reduce #'v+ world-force-list :initial-value (float-vector 0 0 0))
+                        (v+
+                         (reduce #'v+ (mapcar #'(lambda (p f) (v* (scale 1e-3 p) f)) contact-points world-force-list)
+                                 :initial-value (float-vector 0 0 0))
+                         (reduce #'v+ world-moment-list :initial-value (float-vector 0 0 0)))))
+          (ret2
+           ;; World grasp matrix
+           (transform
+            (send *sample-robot* :calc-grasp-matrix contact-points)
+            (apply
+             #'concatenate
+             float-vector
+             (flatten
+              (mapcar #'(lambda (f m) (list f m)) world-force-list world-moment-list)))))
+          (ret3
+           ;; Local grasp matrix
+           (transform
+            (send *sample-robot* :calc-grasp-matrix contact-points :contact-rots contact-rots)
+            (apply
+             #'concatenate
+             float-vector
+             (flatten
+              (mapcar #'(lambda (f m) (list f m)) local-force-list local-moment-list))))))
+      (and (eps-v= ret1 ret2) (eps-v= ret1 ret3))
+      )))
+
 (run-all-tests)
 (exit 0)


### PR DESCRIPTION
Update :calc-grasp-matrix to support contact rot matrices.
Add documentation strings and add test codes.