### PR TITLE
Fasten access for end-coords and root-link by not using assoc searching

### DIFF
--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -97,18 +97,31 @@
                                                      head-end-coords torso-end-coords))))
      )
    )
+  ;; End-coords accessor
+  (:rarm-end-coords () rarm-end-coords)
+  (:larm-end-coords () larm-end-coords)
+  (:rleg-end-coords () rleg-end-coords)
+  (:lleg-end-coords () lleg-end-coords)
+  (:head-end-coords () head-end-coords)
+  (:torso-end-coords () torso-end-coords)
+  ;; Root-link accessor
+  (:rarm-root-link () rarm-root-link)
+  (:larm-root-link () larm-root-link)
+  (:rleg-root-link () rleg-root-link)
+  (:lleg-root-link () lleg-root-link)
+  (:head-root-link () head-root-link)
+  (:torso-root-link () torso-root-link)
   (:limb
    (limb method &rest args)
    (let (ret)
      (case method
        (:end-coords 
 	(user::forward-message-to 
-	 (cdr (assoc (intern (format nil "~A-END-COORDS" (string-upcase limb)))
-		     (send self :slots)))
+         (send self (read-from-string (format nil "~A-END-COORDS" limb)))
 	 args))
        (:root-link
 	(user::forward-message-to 
-	 (cdr (assoc (intern (format nil "~A-ROOT-LINK" (string-upcase limb))) (send self :slots)))
+         (send self (read-from-string (format nil "~A-ROOT-LINK" limb)))
 	 args))
        (:angle-vector
 	(if args


### PR DESCRIPTION
Accessors of `:end-coords` and `:root-link` are currently implemented by `assoc` searching.
In IK codes, these methods are frequently called and `assoc` slowness becomes problem in my IK codes.

I improve these methods using faster accessing by adding accessor methods.

Testing codes
```
(progn                                                                                                                                    
(load "irteus/demo/sample-robot-model.l")                                                                                                                                 
(setq *robot* (instance sample-robot :init))                                                                                                                              
(bench2 (dotimes (i 10000) (send *robot* :rarm :end-coords)))                                                                                                             
)
```

Old code => 0.207327[s]
New code => 0.021465[s]
New code is 10 times faster.