### PR TITLE
[irteus/irtdyna.l] match the order of target-coords and link-list and…

### DIFF
--- a/irteus/demo/walk-motion.l
+++ b/irteus/demo/walk-motion.l
@@ -81,7 +81,7 @@
 (warn "(walk-motion-single-support-for-sample-robot) ;; for walking motion~%")
 
 (defun quad-walk-motion-for-sample-robot
-  (gen-footstep-func &key (go-backward-over t))
+  (gen-footstep-func &key (go-backward-over t) (rotation-axis (list t t t t)))
   (unless (boundp '*robot*)
     (setq *robot* (instance sample-robot :init)))
   ;; initial quad pose
@@ -106,6 +106,7 @@
          (list :min (float-vector -1e10 -1e10 -1e10 -180 -180 -180)
                :max (float-vector  1e10  1e10  1e10  180  180  180)
                :joint-args '(:absolute-p t)
+               :rotation-axis rotation-axis
                :additional-nspace-list
                (list
                 (list (car (send *robot* :links))
@@ -143,10 +144,11 @@
       )))
 
 (defun trot-walk-motion-for-sample-robot
-  (&key (go-backward-over t))
+  (&key (go-backward-over t) (rotation-axis (list t t nil nil)))
   (quad-walk-motion-for-sample-robot
    #'(lambda () (send *robot* :go-pos-quadruped-params->footstep-list 200 100 0 :type :trot))
-   :go-backward-over go-backward-over))
+   :go-backward-over go-backward-over
+   :rotation-axis rotation-axis))
 (warn "(trot-walk-motion-for-sample-robot) ;; for walking motion~%")
 
 (defun crawl-walk-motion-for-sample-robot

--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1908,17 +1908,17 @@
   (:solve-av-by-move-centroid-on-foot
    (support-leg support-leg-coords swing-leg-coords cog robot
    &rest args &key (cog-gain 3.5) (stop 100) (additional-nspace-list) &allow-other-keys)
-   (let ((legs
-          (append (send self :get-counter-footstep-limbs support-leg)
-                  support-leg))
-         (fix-coords (append swing-leg-coords support-leg-coords)))
+   (let* ((legs (append (send self :get-counter-footstep-limbs support-leg)
+                        support-leg))
+          (leg-order (mapcar #'(lambda (l) (position l legs)) all-limbs))
+          (fix-coords (append swing-leg-coords support-leg-coords)))
      (unless (memq :thre args)
-       (append args (list :thre (mapcar #'(lambda (x) (if (memq x '(:rleg :lleg)) ik-thre (* 5 ik-thre))) legs))))
+       (append args (list :thre (mapcar #'(lambda (x) (if (memq x '(:rleg :lleg)) ik-thre (* 5 ik-thre))) all-limbs))))
      (unless (memq :rthre args)
-       (append args (list :rthre (mapcar #'(lambda (x) (deg2rad (if (memq x '(:rleg :lleg)) ik-rthre (* 5 ik-rthre)))) legs))))
+       (append args (list :rthre (mapcar #'(lambda (x) (deg2rad (if (memq x '(:rleg :lleg)) ik-rthre (* 5 ik-rthre)))) all-limbs))))
      (send* robot :move-centroid-on-foot
-            :both legs :target-centroid-pos cog
-            :fix-limbs-target-coords fix-coords
+            :both all-limbs :target-centroid-pos cog
+            :fix-limbs-target-coords (mapcar #'(lambda (idx) (elt fix-coords idx)) leg-order)
             :cog-gain cog-gain :stop stop
             :additional-nspace-list
             (append

--- a/irteus/test/irteus-demo.l
+++ b/irteus/test/irteus-demo.l
@@ -48,6 +48,11 @@
    (not (some #'null (mapcar #'(lambda (x) (cadr (memq :angle-vector x)))
                              (trot-walk-motion-for-sample-robot :go-backward-over nil))))))
 
+(deftest test-trot-walk-motion-for-sample-robot-with-sphere-hand
+  (assert
+   (not (some #'null (mapcar #'(lambda (x) (cadr (memq :angle-vector x)))
+                             (trot-walk-motion-for-sample-robot :go-backward-over nil :rotation-axis (list t t nil nil)))))))
+
 (deftest test-crawl-walk-motion-for-sample-robot-go-backward-over
   (assert
    (not (some #'null (mapcar #'(lambda (x) (cadr (memq :angle-vector x)))


### PR DESCRIPTION
… rotation-axis, translation-axis, thre, rthre and so on

argsで渡されるrotation-axisやtranslation-axisはall-limbsと一致している（一致させたい）のに対し，
target-coordsが``(list swg-A swg-B ... sup-A sup-B ...)``のように遊脚->支持脚の順となっているため，
腕のrotation-axisはnil，足のrotation-axisはt，というようなlimbごとの指定ができませんでした．

ので，target-coordsとlink-listをall-limbsの順に並び替えるようにしました．