### PR TITLE
[irteus/test/vector.l] fix compare NaN

### DIFF
--- a/irteus/test/vector.l
+++ b/irteus/test/vector.l
@@ -115,7 +115,8 @@
     (format *error-output* "v2 = ~A~%" v2)
     (assert (eq (elt v1 0) (elt v2 0)))
     (assert (eq (elt v1 1) (elt v2 1)))
-    (assert (eq (elt v1 2) (elt v2 2)))
+    (assert (not (= (elt v1 2) (elt v1 2)))) ;; this is only the way to compare NaN
+    (assert (not (= (elt v2 2) (elt v2 2))))
     t))
 
 (run-all-tests)


### PR DESCRIPTION
I think https://github.com/euslisp/jskeus/pull/354 is not correct test case.
In C language, `NaN` is compared only by checking `x != x` is `true` when `x` is `NaN`.
c.f. http://stackoverflow.com/questions/15268864/how-to-compare-two-nan-values-in-c