### PR TITLE
test/transparent.l: fix for osx, ru_maxrss retuns huge value on osx, so we check if the growth rate of vmrss

### DIFF
--- a/irteus/test/transparent.l
+++ b/irteus/test/transparent.l
@@ -17,19 +17,20 @@
 
 ;;memory_leak_transparent
 (deftest memory-leak-transparent
-  (let (vmrss)
+  (let (vmrss-orig vmrss)
     (setq *cubes* (make-cubes 5000))
     (send *irtview0* :objects *cubes*)
     (send *irtview1* :objects *cubes*)
     (print "start")
+    (setq vmrss-orig (elt (unix::getrusage 0) 2))
     (dotimes (i 30)
       (mapcar #'(lambda (a) (gl::transparent a (/ i 30.0))) *cubes*)
       (send *irtview0* :draw-objects)
       (send *irtview1* :draw-objects)
       ;;(print (get (car *cubes*) :GL-DISPLAYLIST-ID))
       (setq vmrss (elt (unix::getrusage 0) 2))
-      (format *error-output* "~A gc:~A, vmrss:~A~%" i (sys::gc) vmrss)
-      (assert (< vmrss 300000) "check memory leak")
+      (format *error-output* "~A gc:~A, vmrss:~A(~A)~%" i (sys::gc) vmrss vmrss-orig)
+      (assert (< vmrss (* 4 vmrss-orig)) "check memory leak")
       )))
 
 (run-all-tests)


### PR DESCRIPTION
max rss value for osx and linux is very different...

osx:
```
EusLisp 9.16(8f79f0c 8f79f0c) for Darwin created on elcapitanvm.local(Sun Nov 29 14:24:42 PST 2015)
irteusgl$ unix::rusage
user time 0.2 sec
system time 0.0 sec
max resident core 50872320 Kb
integral resident   0 Kb
page faults without I/O 3836 
page faults with I/O   0 
swaps         0 
input op.     3 
output op.    0 
message sent  0 
message rcvd  0 
signals       0 
volutary sw.  4 
involutary sw.19 
nil

```

linux:
```
EusLisp 9.18( 1.0.12) for Linux64 created on ip-172-31-2-94(Tue Apr 19 22:36:41 PDT 2016)
1.irteusgl$ unix::rusage
user time 0.1 sec
system time 0.0 sec
max resident core 173184 Kb
integral resident   0 Kb
page faults without I/O 5651 
page faults with I/O   0 
swaps         0 
input op.     0 
output op.    0 
message sent  0 
message rcvd  0 
signals       0 
volutary sw.  31 
involutary sw.121 

```