### PR TITLE
irtmodel.l manipulability need to take into account weight value

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -1053,7 +1053,7 @@
     &allow-other-keys)
    (let (jacobi# m m2 (k 0))
      ;; m : manipulability
-     (setq m (manipulability jacobi tmp-mrr tmat))
+     (setq m (manipulability (if weight (m* jacobi (diagonal weight)) jacobi) tmp-mrr tmat))
      (if (< m ml) (setq k (* mg (expt (- 1.0 (/ m  ml)) 2))))
      (when (and debug-view (not (memq :no-message debug-view)))
        (warn "k     :~7,3f (manipulability:~7,3f, gain:~7,3f, limit:~7,3f, len:~d)~%" k m mg ml (cadr (array-dimensions jacobi))))


### PR DESCRIPTION
this problem is addressed in https://github.com/start-jsk/jsk_apc/issues/1470#issuecomment-220518802 and https://github.com/start-jsk/jsk_apc/pull/1529#issuecomment-221239661 where

- use 8 dof robot, 7 arm + gripper
- when we use 8dof + weight to ignore gripper joint, ik fails (see the first log of https://github.com/start-jsk/jsk_apc/pull/1529#issuecomment-221239661)
- when we set 7dof arm via link-list, ik succeeds (see the second log of https://github.com/start-jsk/jsk_apc/pull/1529#issuecomment-221239661)

- if we look the log closer, the manpiulability and 'k' value differs

- need discussion, test code and also we need to pass matrix variable for speedup