### PR TITLE
add condition for wheter there is virtual-link or not

### DIFF
--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -581,7 +581,7 @@
 	 ;; buffers for calculation
 	 (tmp-va (float-vector 0 0 0)))
    (if debug-view (format t ";; forward-all-kinematics link = ~A~%" (send self :name)))
-   (when parent-link
+   (when (and parent-link (derivedp (send self :parent) bodyset-link)) ;; exclude if root-link
      (let* ((paxis (case (joint . axis)
 		     (:x #f(1 0 0)) (:y #f(0 1 0)) (:z #f(0 0 1))
 		     (:xx #f(1 0 0)) (:yy #f(0 1 0)) (:zz #f(0 0 1))
@@ -658,7 +658,7 @@
      (setq force (v+ force (send child :force) force)
 	   moment (v+ moment (send child :moment) moment)))
 
-   (when (and joint parent-link)
+   (when (and joint parent-link (derivedp (send self :parent) bodyset-link)) ;; exclude if root-link
      (send joint :joint-torque
 	   (+ (v. (send self :get :spacial-velocity-jacobian) force)
 	      (v. (send self :get :angular-velocity-jacobian) moment))))

--- a/irteus/test/test-irt-motion.l
+++ b/irteus/test/test-irt-motion.l
@@ -997,5 +997,16 @@
       (and (eps-v= ret1 ret2) (eps-v= ret1 ret3))
       )))
 
+(deftest test-torque-with-root-joint
+  (let* ((torque-without-root-joint (send *sample-robot* :calc-torque :calc-statics-p t))
+         (torque-with-root-joint
+          (with-append-root-joint
+           (link-list-with-robot-6dof *sample-robot* (list (cdr (send *sample-robot* :links)))
+                                      :joint-class 6dof-joint)
+           (send *sample-robot* :calc-torque :calc-statics-p t)
+           )))
+    (assert (eps-v= torque-without-root-joint torque-with-root-joint))
+    ))
+
 (run-all-tests)
 (exit 0)


### PR DESCRIPTION
virtual-linkが存在してもparent-linkを参照しにいってエラーが出ないように、parent-linkが存在するかどうかの条件式にvirtual-linkに関する条件を加えました。