### PR TITLE
[irtdyna/] describe coordinates used in :calc-zmp and :calc-static-balance-point. refer #415, #419

### DIFF
--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -906,6 +906,8 @@
           (update t) (debug-view)
           (calc-torque-buffer-args (send self :calc-torque-buffer-args)))
     "Calculate Zero Moment Point based on Inverse Dynamics.
+     The output is expressed by the world coordinates, 
+     and depends on historical robot states of the past 3 steps. Step is incremented when this method is called.
      After solving Inverse Dynamics, ZMP is calculated from total root-link force and moment.
      necessary arguments -> av and root-coords.
      If update is t, call inverse dynamics, otherwise, just return zmp from total root-link force and moment.

--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -1011,6 +1011,7 @@
          (static-balance-point-height (elt (apply #'midpoint 0.5 (send self :legs :end-coords :worldpos)) 2))
          (update-mass-properties t))
    "Calculate static balance point which is equivalent to static extended ZMP.
+    The output is expressed by the world coordinates.
     target-points are end-effector points on which force-list and moment-list apply.
     force-list [N] and moment-list [Nm] are list of force and moment at target-points.
     static-balance-point-height is height of static balance point [mm]."


### PR DESCRIPTION
:calc-zmp と :calc-static-balance-pointの返り値の座標系に関する記述を追加しました．