### PR TITLE
fix load time.l in current directory

### DIFF
--- a/irteus/irtext.l
+++ b/irteus/irtext.l
@@ -28,7 +28,7 @@
   (load-library
    (format nil "~A~A/lib/libirteus"
 	   *eusdir* (unix:getenv "ARCHDIR"))
-   '("irtmath" "irtutil" "irtc" "irtgeoc" "irtgraph" "pgsql")))
+   '("irtmath" "irtutil" "irtc" "irtgeoc" "irtgraph" "___time" "___pgsql")))
 (defun load-irteusg ()
   (in-package "GEOMETRY")
   (load-library


### PR DESCRIPTION
Issue #292 is not solved, if we have `time.l` in current directory and that file has error, we can not start `irteusgl`

`load-library "time"` did not work because (maybe) we already have `time` function within libc or something similear,
so we need to call `load-library "___time"` to avoid this problem, once we load "time" from `libirteus.so`, then
`pgsql.l` just call `require :time "time"`, so it do not load "time.l" from current directory