### PR TITLE
CMakeList.txt: enable to run compile when .o is removed

### DIFF
--- a/irteus/Makefile
+++ b/irteus/Makefile
@@ -59,8 +59,8 @@ IRTEUS_OSFX=$(addsuffix .$(OSFX),$(IRTEUS))
 IRTEUS_LSFX=$(addsuffix .$(LSFX),$(IRTEUS))
 IRTEUSOBJS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUS_OSFX))
 IRTEUSDLLS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUS_LSFX))
-IRTEUS_C=$(addsuffix .c,$(IRTEUS))
-IRTEUS_H=$(addsuffix .h,$(IRTEUS))
+IRTEUS_C=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .c,$(IRTEUS)))
+IRTEUS_H=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .h,$(IRTEUS)))
 IRTEUS_L=$(addsuffix .l,$(IRTEUS))
 IRTEUS_L:=$(subst pgsql.l,$(EUSDIR)/lib/llib/pgsql.l,$(IRTEUS_L))
 IRTEUS_L:=$(subst time.l,$(EUSDIR)/lib/llib/time.l,$(IRTEUS_L))
@@ -69,32 +69,32 @@ IRTEUSG_OSFX=$(addsuffix .$(OSFX),$(IRTEUSG))
 IRTEUSG_LSFX=$(addsuffix .$(LSFX),$(IRTEUSG))
 IRTEUSGOBJS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSG_OSFX))
 IRTEUSGDLLS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSG_LSFX))
-IRTEUSG_C=$(addsuffix .c,$(IRTEUSG))
-IRTEUSG_H=$(addsuffix .h,$(IRTEUSG))
+IRTEUSG_C=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .c,$(IRTEUSG)))
+IRTEUSG_H=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .h,$(IRTEUSG)))
 IRTEUSG_L=$(addsuffix .l,$(IRTEUSG))
 
 IRTEUSX_OSFX=$(addsuffix .$(OSFX),$(IRTEUSX))
 IRTEUSX_LSFX=$(addsuffix .$(LSFX),$(IRTEUSX))
 IRTEUSXOBJS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSX_OSFX))
 IRTEUSXDLLS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSX_LSFX))
-IRTEUSX_C=$(addsuffix .c,$(IRTEUSX))
-IRTEUSX_H=$(addsuffix .h,$(IRTEUSX))
+IRTEUSX_C=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .c,$(IRTEUSX)))
+IRTEUSX_H=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .h,$(IRTEUSX)))
 IRTEUSX_L=$(addsuffix .l,$(IRTEUSX))
 
 IRTEUSIMG_OSFX=$(addsuffix .$(OSFX),$(IRTEUSIMG))
 IRTEUSIMG_LSFX=$(addsuffix .$(LSFX),$(IRTEUSIMG))
 IRTEUSIMGOBJS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSIMG_OSFX))
 IRTEUSIMGDLLS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSIMG_LSFX))
-IRTEUSIMG_C=$(addsuffix .c,$(IRTEUSIMG))
-IRTEUSIMG_H=$(addsuffix .h,$(IRTEUSIMG))
+IRTEUSIMG_C=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .c,$(IRTEUSIMG)))
+IRTEUSIMG_H=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .h,$(IRTEUSIMG)))
 IRTEUSIMG_L=$(patsubst eusjpeg.l,$(EUSDIR)/lisp/image/jpeg/eusjpeg.l,$(addsuffix .l,$(IRTEUSIMG)))
 
 IRTEUSGL_OSFX=$(addsuffix .$(OSFX),$(IRTEUSGL))
 IRTEUSGL_LSFX=$(addsuffix .$(LSFX),$(IRTEUSGL))
 IRTEUSGLOBJS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSGL_OSFX))
 IRTEUSGLDLLS=$(addprefix $(INSTALLOBJDIR)/,$(IRTEUSGL_LSFX))
-IRTEUSGL_C=$(addsuffix .c,$(IRTEUSGL))
-IRTEUSGL_H=$(addsuffix .h,$(IRTEUSGL))
+IRTEUSGL_C=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .c,$(IRTEUSGL)))
+IRTEUSGL_H=$(addprefix $(INSTALLOBJDIR)/,$(addsuffix .h,$(IRTEUSGL)))
 IRTEUSGL_L=$(addsuffix .l,$(IRTEUSGL))
 
 IRTCOBJECTS=$(INSTALLOBJDIR)/irtc.$(OSFX) $(INSTALLOBJDIR)/irtgeoc.$(OSFX)
@@ -123,27 +123,27 @@ $(LIBIRTEUSGL): $(IRTEUSGLOBJS) $(IRTGLCOBJECTS)
 	$(LD) $(SOFLAGS) $(OUTOPT)$(LIBIRTEUSGL) $(IRTEUSGLOBJS) $(IRTGLCOBJECTS) $(IMPLIB)
 
 $(IRTEUSOBJS): $(INSTALLOBJDIR)/compile_irt.log
-$(INSTALLOBJDIR)/compile_irt.log: $(IRTEUS_L)
+$(IRTEUSOBJS) $(INSTALLOBJDIR)/compile_irt.log: $(IRTEUS_L)
 	$(BINDIR)/eus2$(ESFX) "(setq *objdir* \"$(INSTALLOBJDIR)/\")" < ./compile_irt.l > $(INSTALLOBJDIR)/compile_irt.log
 	-rm -f $(IRTEUS_C) $(IRTEUS_H)
 
 $(IRTEUSGOBJS): $(INSTALLOBJDIR)/compile_irtg.log
-$(INSTALLOBJDIR)/compile_irtg.log: $(IRTEUSG_L)
+$(IRTEUSGOBJS) $(INSTALLOBJDIR)/compile_irtg.log: $(IRTEUSG_L)
 	$(BINDIR)/eusgl$(ESFX) "(setq *objdir* \"$(INSTALLOBJDIR)/\")" < ./compile_irtg.l > $(INSTALLOBJDIR)/compile_irtg.log
 	-rm -f $(IRTEUSG_C) $(IRTEUSG_H)
 
 $(IRTEUSXOBJS): $(INSTALLOBJDIR)/compile_irtx.log
-$(INSTALLOBJDIR)/compile_irtx.log: $(IRTEUSX_L)
+$(IRTEUSXOBJS) $(INSTALLOBJDIR)/compile_irtx.log: $(IRTEUSX_L)
 	$(BINDIR)/eusx$(ESFX) "(setq *objdir* \"$(INSTALLOBJDIR)/\")" < ./compile_irtx.l > $(INSTALLOBJDIR)/compile_irtx.log
 	-rm -f $(IRTEUSX_C) $(IRTEUSX_H)
 
 $(IRTEUSIMGOBJS): $(INSTALLOBJDIR)/compile_irtimg.log
-$(INSTALLOBJDIR)/compile_irtimg.log: $(IRTEUSIMG_L)
+$(IRTEUSIMGOBJS) $(INSTALLOBJDIR)/compile_irtimg.log: $(IRTEUSIMG_L)
 	$(BINDIR)/eusx$(ESFX) "(setq *objdir* \"$(INSTALLOBJDIR)/\")" < ./compile_irtimg.l > $(INSTALLOBJDIR)/compile_irtimg.log
 	-rm -f $(IRTEUSIMG_C) $(IRTEUSIMG_H)
 
 $(IRTEUSGLOBJS): $(INSTALLOBJDIR)/compile_irtgl.log
-$(INSTALLOBJDIR)/compile_irtgl.log: $(IRTEUSGL_L)
+$(IRTEUSGLOBJS) $(INSTALLOBJDIR)/compile_irtgl.log: $(IRTEUSGL_L)
 	$(BINDIR)/eusgl$(ESFX) "(setq *objdir* \"$(INSTALLOBJDIR)/\")" < ./compile_irtgl.l > $(INSTALLOBJDIR)/compile_irtgl.log
 	-rm -f $(IRTEUSGL_C) $(IRTEUSGL_H)
 


### PR DESCRIPTION
currently if we remove time.o and re-run make, we had compile error like
```
[jskeus:install]   ARCHDIR=Linux64                                                                                                
[jskeus:install]   EUSDIR=/home/k-okada/catkin_ws/ws_euslisp/devel/share/euslisp/jskeus/eus                                       
[jskeus:install]   IRTEUSDIR=/home/k-okada/catkin_ws/ws_euslisp/devel/share/euslisp/jskeus/eus/                                   
[jskeus:install]   'SVNVERSION=\"1.1.0\"' VERBOSE=1                                                                               
[jskeus:install]                                                                                                                  
[jskeus:install]   make[5]: Entering directory                                                                                    
[jskeus:install]   `/home/k-okada/catkin_ws/ws_euslisp/src/jskeus/irteus'                                                         
[jskeus:install]                                                                                                                  
[jskeus:install]   make[5]: Leaving directory                                                                                     
[jskeus:install]   `/home/k-okada/catkin_ws/ws_euslisp/src/jskeus/irteus'                                                         
[jskeus:install]                                                                                                                  
[jskeus:install]   make[5]: *** No rule to make target                                                                            
[jskeus:install]   `/home/k-okada/catkin_ws/ws_euslisp/devel/share/euslisp/jskeus/eus//Linux64/obj/irtmath.l',                    
[jskeus:install]   needed by                                                                                                      
[jskeus:install]   `/home/k-okada/catkin_ws/ws_euslisp/devel/share/euslisp/jskeus/eus//Linux64/obj/irtmath.o'.                    
[jskeus:install]   Stop.                                                                                                          
[jskeus:install]                                                                                                                  
[jskeus:install]   make[4]: Leaving directory                                                                                     
[jskeus:install]   `/home/k-okada/catkin_ws/ws_euslisp/build/jskeus'                                                              
[jskeus:install]                                                                                                                  
[jskeus:install]   make[4]: *** [CMakeFiles/compile_jskeus] Error 2                                                               
[jskeus:install]                                                                                                                  
[jskeus:install]   make[3]: Leaving directory                                                                                     
[jskeus:install]   `/home/k-okada/catkin_ws/ws_euslisp/build/jskeus'                                                              
[jskeus:install]                                                                                                                  
[jskeus:install]   make[3]: *** [CMakeFiles/compile_jskeus.dir/all] Error 2                                                       
[jskeus:install]                                                                                                                  
[jskeus:install]   make[2]: *** [CMakeFiles/compile_jskeus.dir/rule] Error 2                                                      
[jskeus:install]                                                                                  
```