### PR TITLE
Fix camera model

### DIFF
--- a/irteus/demo/sample-camera-model.l
+++ b/irteus/demo/sample-camera-model.l
@@ -82,7 +82,57 @@
   (image::write-pnm-file "sample-get-camera-image-2c.ppm" (send *camera-model* :get-image))
   )
 
+(defun sample-robot-camera ()
+  (let (r b g c1 c2)
+    (load "irteus/demo/sample-robot-model.l")
+    (setq r (instance sample-robot :init))
+    (send r :fix-leg-to-coords (make-coords))
+    (setq b (make-cube 100 100 100 :pos #f(1000 1000 1000)))
+    (send b :set-color :red)
+    (setq g (make-cube 3000 3000 1))
+    (send g :set-color :gray90)
+    (objects (list r b g))
+
+    ;; get camera model
+    (setq c1 (send r :camera "left-camera"))
+    (setq c2 (send r :camera "right-camera"))
+
+    ;; display coordinates
+    (send (send c1 :copy-worldcoords) :draw-on :flush t :size 1000)
+
+    ;; display view
+    (send c1 :draw-on :flush t)
+
+    ;; get view angle
+    (format t "view-angle ~A [deg]~%" (rad2deg (send c1 :viewing :view-angle)))
+
+    ;; display view image
+    (send c1 :draw-objects (list b g))
+    ;; save view image
+    (image::write-png-file "camera-image.png" (send c1 :get-image))
+
+    ;; git object position in image coordinates
+    (setq sp1 (send c1 :screen-point (send b :worldpos)))
+    (format t "screen point ~A (left)~%" sp1)
+
+    ;; get ray of found objects
+    (setq r1 (send c1 :ray (elt sp1 0) (elt sp1 1)))
+    (setq l1 (make-line (send c1 :worldpos) (v+ (send c1 :worldpos) (scale 2000 r1))))
+    (send l1 :draw-on :flush t)
+    (objects l1)
+
+    ;; stereo proceessing
+    (setq sp2 (send c2 :screen-point (send b :worldpos))) ;; get image coordinates
+    (setq r2 (send c1 :ray (elt sp2 0) (elt sp2 1)))        ;; get ray
+    (setq l2 (make-line (send c2 :worldpos) (v+ (send c2 :worldpos) (scale 2000 r2)))) ;; make line
+    (objects l2)
+    (send l1 :common-perpendicular l2) ;; end-points of the line vertical both to l1 and l2
+    (setq p (apply #'midpoint 0.5 (send l1 :common-perpendicular l2)))
+    ;;
+    (format t "check  stereo processing ~A~%" (eps-v= (send b :worldpos) p)) ;; check
+    ))
 
 (warn ";; run demo program~%")
 (warn "(sample-get-camera-image-1)~%")
 (warn "(sample-get-camera-image-2)~%")
+(warn "(sample-robot-camera)~%")

--- a/irteus/demo/sample-robot-model.l
+++ b/irteus/demo/sample-robot-model.l
@@ -140,6 +140,7 @@
            (mapcar #'(lambda (pos name)
                        (let ((sen (instance camera-model :init (make-cylinder 10 20) :name name)))
                          (send sen :rotate pi/2 :y)
+                         (send sen :rotate -pi/2 :z)
                          (send sen :locate (v+ pos (send (car (send (send self :head :neck-p :child-link) :bodies)) :centroid)) :world)
                          (send (send self :head :neck-p :child-link) :assoc sen)
                          sen))

--- a/irteus/irtsensor.l
+++ b/irteus/irtsensor.l
@@ -75,7 +75,7 @@
 (defclass camera-model
   :super sensor-model
   :slots ((vwing :forward
-                   (:projection :newprojection
+                   (:projection :newprojection :screen
                     :view :viewpoint :view-direction :viewdistance
                     :yon :hither))
           img-viewer pwidth pheight))
@@ -192,7 +192,8 @@
           (vp (send self :viewpoint))
           (r (/ hither viewdistance))
           (rr (/ yon viewdistance))
-          (screenx 1.0) (screeny 1.0))
+          (screen (send self :screen))
+          (screenx (car screen)) (screeny (cadr screen)))
      (send vwer :viewsurface :line-width width)
      (send vwer :viewsurface :color color)
      (gl::glDisable gl::GL_DEPTH_TEST)


### PR DESCRIPTION
afd954a irteus/demo/sample-camera-model.l: add sample-robot-camera

- add sample code to how to use camera model @yuki-asano @yuki-shark

![screenshot from 2017-04-29 20 52 56](https://cloud.githubusercontent.com/assets/493276/25555312/dde2d77a-2d1d-11e7-9e43-b1c5504ab6d4.png)


9331f05 irteus/demo/sample-robot-model.l: fix camera orientation

- X-Y orientation of camera was not correct

08c08e8 irteus/irtsensor.l: (defmethod camera-model (:draw-sensor )) use screen of viewing

- this  will change the current behavior, the view angle of the camera is ~60 [deg] so I think this change is correct.

before
 ![screenshot from 2017-04-29 18 34 07](https://cloud.githubusercontent.com/assets/493276/25555290/64f1869a-2d1d-11e7-9f7a-2540e6adb748.png)

after
 ![screenshot from 2017-04-29 18 33 34](https://cloud.githubusercontent.com/assets/493276/25555289/631d8a26-2d1d-11e7-8083-2cab5ad25c1b.png)





