### PR TITLE
add kbhit()

### DIFF
--- a/irteus/irtutil.l
+++ b/irteus/irtutil.l
@@ -566,6 +566,38 @@ t
            )
          ,flag))))
 
+
+;;; from termbits.h
+(defcstruct termios
+  (c_iflag      :integer)
+  (c_oflag      :integer)
+  (c_cflag      :integer)
+  (c_lflag      :integer)
+  (c_line       :char)
+  (c_cc         :char 19)
+  (c_ispeed     :integer)
+  (c_ospeed     :integer))
+
+(defconstant TCSANOW 0)
+(defconstant TCSADRAIN 1)
+(defconstant TCSAFLUSH 2)
+(defconstant ICANON #0x0002)
+(defun kbhit ()
+  "Checks the console for a keystroke. retuns keycode value if a key has been pressed, otherwise it returns nil. Note that this does not work well on Emacs Shell mode, run EusLisp program from terminal shell."
+  (let ((attr-orig (unix::tcgetattr 0))
+        (buf "0")
+        attr ret)
+    (setq attr (copy-list attr-orig))
+    ;; 1000 1010 0011 1011
+    (setf (termios-c_lflag attr) (logand (termios-c_lflag attr) (lognot ICANON)))
+    (unix::tcsetattr 0 TCSANOW attr)
+    (when (= (unix::select-read-fd 1 0.001) 1)
+      (unix::uread 0 buf 1)
+      (setq ret (elt buf 0)))
+    (unix::tcsetattr 0 TCSANOW attr-orig)
+    ret))
+;;
+
 ;; piped fork returning result as list
 (defun piped-fork-returns-list (cmd &optional args)
   "piped fork returning result as list"


### PR DESCRIPTION
add kbhit function

kbhit() Checks the console for a keystroke. retuns keycode value if a key has been pressed immediately, otherwise it returns nil. Note that this does not work well on Emacs Shell mode, run EusLisp program from terminal shell.

see https://github.com/euslisp/jskeus/issues/30, https://github.com/euslisp/EusLisp/pull/237

```
(dotimes (i 10)
  (setq c (kbhit))
  (if c
     (format t "~c(~d)~%" c c))
    (format t "no input...~%"))
  (unix::sleep 1))
```