### PR TITLE
Fix typo in irtutil.l

### DIFF
--- a/irteus/irtutil.l
+++ b/irteus/irtutil.l
@@ -218,7 +218,7 @@
           ;;
           (position :type float-vector)   ;; current data point
           (time :type float)          ;; time [sec] from start
-          (segmnet-num :type integer) ;; number of total segment
+          (segment-num :type integer) ;; number of total segment
           (segment-time :type float)  ;; time[sec] with in each segment
           (segment :type integer)     ;; index of segment which is currently processing
           (interpolatingp :type symbol)


### PR DESCRIPTION
Fixing typo in irtutil.l : segm**ne**t-num -> segm**en**t-num .

Further reference in the file points to `segment-num` slot correctly.