### PR TITLE
Set minjerk end position to last given value

### DIFF
--- a/irteus/irtutil.l
+++ b/irteus/irtutil.l
@@ -278,7 +278,9 @@
      (when (> time (nth segment time-list))
        (setq segment-time (- time (nth segment time-list)))
        (incf segment))
-     (if (>= segment segment-num) (send self :reset))
+     (when (>= segment segment-num)
+       (setq position (car (last position-list)))
+       (send self :reset))
      position))
   )
 


### PR DESCRIPTION
Set minjerk interpolator's final position value to given goal position, in order to fix:
```
(setq l (instance minjerk-interpolator :init))
(send l :reset :position-list (list #f(1 2 3) #f(3 4 5) #f(1 2 3)) :time-list (list 1000 1800))
(send l :start-interpolation)
(while (send l :interpolatingp) (send l :pass-time 200) (print (send l :position)))
(send l :position)                ;; #f(1.0 2.0 3.0)                                                  
(v= #f(1 2 3) (send l :position)) ;; nil                                                              
(v- #f(1 2 3) (send l :position)) ;; #f(1.421085e-14 1.421085e-14 1.421085e-14) 
```

Needs debate if this is actually the desired behavior or if the problem should be avoided by using `eps-v=` or reducing time values.

Details in #466 .