### PR TITLE
add documentation to :move-coords

### DIFF
--- a/irteus/irtgeo.l
+++ b/irteus/irtgeo.l
@@ -228,7 +228,8 @@
 				    :inverse-transformation) cc cc)
 	    (send self :newcoords cc))))
   (:move-coords
-   (target at) ;; fix "at" coords on "self" to "target"
+   (target at)
+   "fix 'at' coords on 'self' to 'target'"
    (send self :transform (send at :transformation target) at)
    (send self :worldcoords)
    )


### PR DESCRIPTION
`:move-coords`の使い方が`jmanual`に載っていなかったので載せたいのですが、`irtgeo.l`の中の関数に説明を入れても`jmanual`には反映されないようです。
例えば、`irtgeo.l`の`:difference-position`という関数
https://github.com/euslisp/jskeus/blob/master/irteus/irtgeo.l#L56
は`jmanual`では説明されていません。

どうすれば`irtgeo.l`の関数の説明も`jmanual`に反映されるようになるでしょうか？

CC. @mmurooka 