### PR TITLE
[jskeus/irteus/irtmodel.l][test/joint.l] fix target joint table in :angle-vector and update test

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -817,8 +817,8 @@
                  (setq tmp-joint-angle (elt vec i) tmp-target-joint-angle (elt vec ii))
                  (setq tmp-joint-min-angle (send j :joint-min-max-table-min-angle tmp-target-joint-angle)
                        tmp-joint-max-angle (send j :joint-min-max-table-max-angle tmp-target-joint-angle))
-                 (setq tmp-target-joint-min-angle (send j :joint-min-max-table-min-angle tmp-joint-angle)
-                       tmp-target-joint-max-angle (send j :joint-min-max-table-max-angle tmp-joint-angle))
+                 (setq tmp-target-joint-min-angle (send jj :joint-min-max-table-min-angle tmp-joint-angle)
+                       tmp-target-joint-max-angle (send jj :joint-min-max-table-max-angle tmp-joint-angle))
                  (cond ((<= tmp-joint-min-angle tmp-joint-angle tmp-joint-max-angle) ;; ok
                         ;; force change joint-angle to avoid problem
                         (setq (j . joint-angle) tmp-joint-angle
@@ -829,8 +829,8 @@
                             ((> i 1))
                           (setq tmp-joint-min-angle (send j :joint-min-max-table-min-angle tmp-target-joint-angle)
                                 tmp-joint-max-angle (send j :joint-min-max-table-max-angle tmp-target-joint-angle))
-                          (setq tmp-target-joint-min-angle (send j :joint-min-max-table-min-angle tmp-joint-angle)
-                                tmp-target-joint-max-angle (send j :joint-min-max-table-max-angle tmp-joint-angle))
+                          (setq tmp-target-joint-min-angle (send jj :joint-min-max-table-min-angle tmp-joint-angle)
+                                tmp-target-joint-max-angle (send jj :joint-min-max-table-max-angle tmp-joint-angle))
 
                           (if (< tmp-joint-angle tmp-joint-min-angle)
                               (incf tmp-joint-angle (* (- tmp-joint-min-angle tmp-joint-angle) i)))

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -23,9 +23,9 @@
                                                (make-cube 300 300 2)) #f(0 0 0) :white 'l1))
          (send l1 :assoc l2)
          (setq j1 (instance rotational-joint :init :parent-link l1 :child-link l2 :axis :z
-                            :min-angle -90 :max-angle 90)
+                            :min -90 :max 90)
                j2 (instance rotational-joint :init :parent-link l2 :child-link l3 :axis :y
-                            :min-angle -90 :max-angle 90))
+                            :min -90 :max 90))
          ;;
          (setq links (list l1 l2 l3) joint-list (list j1 j2))
      (send self :init-ending)

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -128,8 +128,8 @@
           ((> x j1-org-max-angle))
         (do ((y j2-org-min-angle (+ y 1)))
             ((> y j2-org-max-angle))
-          (let* ((j1-min-max (cons (aref j1-min-max-table 1 (round (- y (aref j1-min-max-table 0 0)))) (aref j1-min-max-table 2 (round (- y (aref j1-min-max-table 0 0)))))) ;; j1-min-max-table is functoin of j2
-                 (j2-min-max (cons (aref j2-min-max-table 1 (round (- x (aref j2-min-max-table 0 0)))) (aref j2-min-max-table 2 (round (- x (aref j2-min-max-table 0 0))))))
+          (let* ((j1-min-max (cons (aref j1-min-max-table 1 (round (- y j2-org-min-angle))) (aref j1-min-max-table 2 (round (- y j2-org-min-angle))))) ;; j1-min-max-table is functoin of j2
+                 (j2-min-max (cons (aref j2-min-max-table 1 (round (- x j1-org-min-angle))) (aref j2-min-max-table 2 (round (- x j1-org-min-angle)))))
                  (j1-min (car j1-min-max))
                  (j1-max (cdr j1-min-max))
                  (j2-min (car j2-min-max))

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -10,7 +10,7 @@
 (defmethod 2dof-robot
   (:init ()
          (send-super :init)
-         (setq l3 (send self :make-link (make-cube 40 40 80) #f(0 0 40) :read 'l3))
+         (setq l3 (send self :make-link (make-cube 40 40 80) #f(0 0 40) :red 'l3))
          (setq end-coords (make-cascoords :pos #f(0 0 80)))
          (send l3 :assoc end-coords)
          (send l3 :locate #f(0 0 10))

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -96,8 +96,8 @@
 (deftest test-min-max-table
   (let* ((j1 (send *robot* :j1))
          (j2 (send *robot* :j2))
-         (j1-min-max-table (make-matrix 3 (round (+ 1 (- (send j1 :max-angle) (send j1 :min-angle))))))
-         (j2-min-max-table (make-matrix 3 (round (+ 1 (- (send j2 :max-angle) (send j2 :min-angle))))))
+         (j1-min-max-table (make-matrix 3 (round (+ 1 (- (send j2 :max-angle) (send j2 :min-angle))))))
+         (j2-min-max-table (make-matrix 3 (round (+ 1 (- (send j1 :max-angle) (send j1 :min-angle))))))
          (j1-org-min-angle (send j1 :min-angle)) (j2-org-min-angle (send j2 :min-angle))
          (j1-org-max-angle (send j1 :max-angle)) (j2-org-max-angle (send j2 :max-angle))
          min-max-table-view

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -170,8 +170,9 @@
           (if min-max-table-view
               (format t ";; Is (~A ~A) safe posture? ~A ~A~%" x y (and (= x (send j1 :joint-angle)) (= y (send j2 :joint-angle))) (<= (abs y) (- 90 (abs x))))))
         ;; check in view
-        (cond ((and (= x (send j1 :joint-angle)) (= y (send j2 :joint-angle)) min-max-table-view) ;; with i nlimit
-               (send min-max-table-view :color #x0000ff))
+        (cond ((and (= x (send j1 :joint-angle)) (= y (send j2 :joint-angle))) ;; with i nlimit
+               (if min-max-table-view
+                   (send min-max-table-view :color #x0000ff)))
               (t ;; out of limit
                (if min-max-table-view (format t ";; out of limit ~A -> ~A~%" (float-vector x y) (send *robot* :angle-vector)))
                (let* ((j1-max-angle

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -189,8 +189,11 @@
                        (- j2-max-angle)))
                  (setq ret
                        (and ret
-                            (< (- j1-min-angle *epsilon*) (send j1 :joint-angle) (+ j1-max-angle *epsilon*))
-                            (< (- j2-min-angle *epsilon*) (send j2 :joint-angle) (+ j2-max-angle *epsilon*)))))
+                            (and (or (< (- j1-min-angle *epsilon*) (send j1 :joint-angle) (+ j1-min-angle *epsilon*))
+                                     (< (- j1-max-angle *epsilon*) (send j1 :joint-angle) (+ j1-max-angle *epsilon*)))
+                                 (or (< (- j2-min-angle *epsilon*) (send j2 :joint-angle) (+ j2-min-angle *epsilon*))
+                                     (< (- j2-max-angle *epsilon*) (send j2 :joint-angle) (+ j2-max-angle *epsilon*))))
+                            )))
                (when min-max-table-view
                  (send min-max-table-view :color #xff0000)
                  (send min-max-table-view :draw-line

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -23,9 +23,9 @@
                                                (make-cube 300 300 2)) #f(0 0 0) :white 'l1))
          (send l1 :assoc l2)
          (setq j1 (instance rotational-joint :init :parent-link l1 :child-link l2 :axis :z
-                            :min -90 :max 90)
+                            :min -90.0 :max 90.0)
                j2 (instance rotational-joint :init :parent-link l2 :child-link l3 :axis :y
-                            :min -90 :max 90))
+                            :min -60.0 :max 60.0))
          ;;
          (setq links (list l1 l2 l3) joint-list (list j1 j2))
      (send self :init-ending)

--- a/irteus/test/joint.l
+++ b/irteus/test/joint.l
@@ -107,9 +107,14 @@
     ;; j1-hash
     (mapcar #'(lambda (self-joint target-joint j-min-max-table)
                 (do ((i (round (send target-joint :min-angle)) (+ i 1))) ((> i (round (send target-joint :max-angle))))
-                    (setf (aref j-min-max-table 0 (round (- i (send self-joint :min-angle)))) i)
-                    (setf (aref j-min-max-table 1 (round (- i (send self-joint :min-angle)))) (- (abs i) (send self-joint :max-angle)))
-                    (setf (aref j-min-max-table 2 (round (- i (send self-joint :min-angle)))) (- (send self-joint :max-angle) (abs i))))
+                    (setf (aref j-min-max-table 0 (round (- i (send target-joint :min-angle)))) i)
+                    (setf (aref j-min-max-table 1 (round (- i (send target-joint :min-angle))))
+                          (- (+ (min (* (/ (send self-joint :max-angle) (send target-joint :max-angle)) i)
+                                     (* -1 (/ (send self-joint :max-angle) (send target-joint :max-angle)) i))
+                                (send self-joint :max-angle))))
+                    (setf (aref j-min-max-table 2 (round (- i (send target-joint :min-angle))))
+                          (- (aref j-min-max-table 1 (round (- i (send target-joint :min-angle))))))
+                    )
                 (send self-joint :joint-min-max-table j-min-max-table)
                 (send self-joint :joint-min-max-target target-joint))
             (list j1 j2)
@@ -169,10 +174,22 @@
                (send min-max-table-view :color #x0000ff))
               (t ;; out of limit
                (if min-max-table-view (format t ";; out of limit ~A -> ~A~%" (float-vector x y) (send *robot* :angle-vector)))
-               (setq ret
-                     (and ret
-                          (< (- (- (abs (send j2 :joint-angle)) (abs j1-org-max-angle)) *epsilon*) (send j1 :joint-angle) (+ (- (abs j1-org-max-angle) (abs (send j2 :joint-angle))) *epsilon*))
-                            (< (- (- (abs (send j1 :joint-angle)) (abs j2-org-max-angle)) *epsilon*) (send j2 :joint-angle) (+ (- (abs j2-org-max-angle) (abs (send j1 :joint-angle))) *epsilon*))))
+               (let* ((j1-max-angle
+                       (+ (min (* (/ j1-org-max-angle j2-org-max-angle) (send j2 :joint-angle))
+                               (* -1 (/ j1-org-max-angle j2-org-max-angle) (send j2 :joint-angle)))
+                          j1-org-max-angle))
+                      (j1-min-angle
+                       (- j1-max-angle))
+                      (j2-max-angle
+                       (+ (min (* (/ j2-org-max-angle j1-org-max-angle) (send j1 :joint-angle))
+                               (* -1 (/ j2-org-max-angle j1-org-max-angle) (send j1 :joint-angle)))
+                          j2-org-max-angle))
+                      (j2-min-angle
+                       (- j2-max-angle)))
+                 (setq ret
+                       (and ret
+                            (< (- j1-min-angle *epsilon*) (send j1 :joint-angle) (+ j1-max-angle *epsilon*))
+                            (< (- j2-min-angle *epsilon*) (send j2 :joint-angle) (+ j2-max-angle *epsilon*)))))
                (when min-max-table-view
                  (send min-max-table-view :color #xff0000)
                  (send min-max-table-view :draw-line


### PR DESCRIPTION
https://github.com/euslisp/jskeus/pull/477 の問題が再現するように test/joint.l のテストを更新し，この問題が解決するようにirtmodel.lの:angle-vectorメソッドを修正しました．
このPRは https://github.com/euslisp/jskeus/pull/477 を含んでいるので https://github.com/euslisp/jskeus/pull/477 はcloseします．

  