### PR TITLE
Fix bug in calculation of :cog-translation-axis

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -2291,11 +2291,7 @@
                                    ;; evaluate additional-jacobi function and calculate row dimension of additional-jacobi
                                    :additional-jacobi-dimension
                                    (+ (if (and (not cog-null-space) target-centroid-pos)
-                                          (case cog-translation-axis
-                                                (t 3)
-                                                ((:x :y :z :xx :yy :zz) 2)
-                                                ((:xy :yx :yz :zy :zx :xz) 1)
-                                                (nil 0))
+                                          (send self :calc-target-axis-dimension nil cog-translation-axis)
                                         0)
                                       (reduce #'+ (mapcar #'(lambda (aj) (array-dimension (if (functionp aj) (funcall aj link-list) aj) 0)) tmp-additional-jacobi)))
                                    :union-link-list union-link-list args) args)))

--- a/irteus/test/test-irt-motion.l
+++ b/irteus/test/test-irt-motion.l
@@ -1121,5 +1121,47 @@
       (send (send root-move-target :parent) :dissoc root-move-target)
       (assert ret "Test multiple link-list with root-link and IK"))))
 
+;; Check :cog-translation-axis dimension bug
+(deftest test-cog-translation-axis-dim
+  (unwind-protect
+      (progn
+        ;; Method overwrite to get method argument for checking
+        (unless (assoc :inverse-kinematics-loop-org (send cascaded-link :methods))
+          (rplaca (assoc :inverse-kinematics-loop (send cascaded-link :methods)) :inverse-kinematics-loop-org))
+        (defmethod cascaded-link
+          (:inverse-kinematics-loop
+           (dif-pos dif-rot &rest args &key ik-args &allow-other-keys)
+           (send self :put :tmp-ik-args ik-args) ;; Store ik-args just for this testing.
+           (send* self :inverse-kinematics-loop-org dif-pos dif-rot :ik-args ik-args args)))
+        ;; Testing
+        (mapcar #'(lambda (caxis caxis-dim)
+                    (assert
+                     (let ((ik-ret)
+                           (ik-target-axis-dim (send *sample-robot* :calc-target-axis-dimension (list t t) (list t t)))) ;; rotation-axis (list t t) and translation-axis (list t t) => dim = 12
+                       ;; Call :fullbody-inverse-kinematics
+                       (send *sample-robot* :reset-pose)
+                       (send *sample-robot* :newcoords (make-coords))
+                       (setq ik-ret
+                             (send *sample-robot* :fullbody-inverse-kinematics
+                                   (list (send *sample-robot* :rleg :end-coords :copy-worldcoords) (send *sample-robot* :lleg :end-coords :copy-worldcoords))
+                                   :move-target (list (send *sample-robot* :rleg :end-coords) (send *sample-robot* :lleg :end-coords))
+                                   :link-list (mapcar #'(lambda (x) (send *sample-robot* :link-list (send x :parent))) (list (send *sample-robot* :rleg :end-coords) (send *sample-robot* :lleg :end-coords)))
+                                   :target-centroid-pos (send *sample-robot* :centroid)
+                                   :cog-translation-axis caxis))
+                       (and ik-ret
+                            (= (cadr (memq :dim (send *sample-robot* :get :tmp-ik-args)))
+                               (+ ik-target-axis-dim caxis-dim)
+                               )))
+                     (format nil ";; Check COG axis dim (:cog-translation-axis = ~A should be dim = ~A)" caxis caxis-dim)))
+                (list t :z :xz nil) ;; :cog-translation-axis
+                (list 3 2 1 0) ;; Desired axis dimension
+                ))
+    ;; Revert method overwrite
+    (defmethod cascaded-link
+      (:inverse-kinematics-loop
+       (dif-pos dif-rot &rest args &key ik-args &allow-other-keys)
+       (send* self :inverse-kinematics-loop-org dif-pos dif-rot :ik-args ik-args args)))
+    ))
+
 (run-all-tests)
 (exit 0)


### PR DESCRIPTION
Fix bug in calculation of :cog-translation-axis.
https://github.com/euslisp/jskeus/blob/master/irteus/irtmodel.l#L2294
```
                                          (case cog-translation-axis
                                                (t 3)
                                                ((:x :y :z :xx :yy :zz) 2)
                                                ((:xy :yx :yz :zy :zx :xz) 1)
                                                (nil 0))
```
This should return 3 for `:cog-translation-axis t`, 2 for `:cog-translation-axis :x`, 1 for `:cog-translation-axis :xy`, 0 for `:cog-translation-axis nil`.
However, this code returns always 3 because of bug of using `case`.

First, I added test code to check the test code fails on travis.
Then, I'll add the fix of it.