### PR TITLE
[irteus/irtmodel.l] check collision if colision-pair is not included in link-list

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -1320,12 +1320,8 @@
      ;; pair (part of this limb . part of another limb)
      (dotimes (i pair-len)
        (setq pair (elt pair-list i))
-       (if (not (memq (car pair) union-link-list)) 
-	   (progn
-             (warn ";; ERROR : (car pair) is not included in link-list ~A~%" (send-all pair :name))
-	     (setf (elt col-list i) nil)
-	     )
-	 (progn
+       (if (and warnp (not (memq (car pair) union-link-list)))
+         (warn ";; !!WARNING!! : (car pair) is not included in link-list ~A~%" (send-all pair :name)))
 	   (setq np (nconc (pqp-collision-distance (car pair) (cadr pair) :qsize 2) (list (float-vector 0 0 0) i)))
 	   (if (<= (car np) distance-limit)
 	       (progn
@@ -1338,7 +1334,7 @@
 	     (progn
 	       (setf (elt col-list i) np)))
            (scale 0.001 (normalize-vector (v- (elt np 1) (elt np 2) (elt np 3)) (elt np 3)) (elt np 3))
-	   ))) ;; dotimes
+	   ) ;; dotimes
      ;; Element of "col-list" (variable "np") is list of:
      ;;   distance-between-pair1<->pair2
      ;;   nearest-point-on-pair1


### PR DESCRIPTION
When `collision-pair` is not included in `link-list`, its collision data `(elt col-list i)` is set as `nil`.

```lisp
(if (not (memq (car pair) union-link-list))
    (progn
      (warn ";; ERROR : (car pair) is not included in link-list ~A~%" (send-all pair :name))
      (setf (elt col-list i) nil)
)
```
https://github.com/euslisp/jskeus/blob/master/irteus/irtmodel.l#L1323-L1327

This cause errors in https://github.com/euslisp/jskeus/blob/master/irteus/irtmodel.l#L1348 and https://github.com/euslisp/jskeus/blob/master/irteus/irtmodel.l#L1429-L1434, because of doing `(elt nil 0)`.

When I came into debugging this problem, I did not understand why there is no collision check for `collision-pair` which are not in `link-list`.
I thought that even if `collision-pair` is not in `link-list`, we should check its collision distance` .