### PR TITLE
[irteus/irtgeo.l] move :move-coords method to coordinates class

### DIFF
--- a/irteus/irtgeo.l
+++ b/irteus/irtgeo.l
@@ -158,6 +158,12 @@
 	(transform-coords (send wrt :worldcoords) self self))
       (t (send self :error ":transform wrt?" wrt)))
    (send self :newcoords rot pos))
+  (:move-coords
+   (target at)
+   "fix 'at' coords on 'self' to 'target'"
+   (send self :transform (send at :transformation target) at)
+   (send self :worldcoords)
+   )
   )
 
 (defmethod cascaded-coords 
@@ -227,12 +233,6 @@
 	    (transform-coords (send (send self :parentcoords)
 				    :inverse-transformation) cc cc)
 	    (send self :newcoords cc))))
-  (:move-coords
-   (target at)
-   "fix 'at' coords on 'self' to 'target'"
-   (send self :transform (send at :transformation target) at)
-   (send self :worldcoords)
-   )
   )
 
 (defun transform-coords (c1 c2 &optional


### PR DESCRIPTION
The useful method `:move-coords` is defined in cascaded-coords class although the method does not depend on cascaded features. How about move this method from cascaded-coords to coordinate?
(This is just for utility so if not so many positive reaction, it's OK to close.)

Now :move-coords method is not defined in coordinate class, so this PR does not change bihavior of current working code.
```lisp
13.irteusgl$ (assoc :move-coords (send coordinates :methods))
nil
14.irteusgl$ (assoc :move-coords (send cascaded-coords :methods))
(:move-coords #<compiled-code #X5d92d88>)
```
