### PR TITLE
to use IMPLIB we need run LIBNR first

### DIFF
--- a/irteus/Makefile
+++ b/irteus/Makefile
@@ -113,7 +113,7 @@ defun.h:
 	$(CC) $(CFLAGS) -c test.c $(OBJOPT) test.o || echo "#define defun(a, b, c, d, e) defun(a, b, c, d) // for EusLisp < 9.24" >> defun.h
 	cat defun.h
 
-$(LIBIRTEUS): $(IRTEUSOBJS) $(IRTCOBJECTS)
+$(LIBIRTEUS): $(IRTEUSOBJS) $(IRTCOBJECTS) $(LIBNR)
 	$(LD) $(SOFLAGS) $(OUTOPT)$(LIBIRTEUS) $(IRTEUSOBJS) \
 		$(IRTCOBJECTS) $(IMPLIB)
 


### PR DESCRIPTION
sometimes we find `cannot find -lnr` problem, this PR add dependency from nr to irtx.o

https://api.travis-ci.org/v3/job/405188058/log.txt

```
(cd /home/travis/jskeus/eus/Linux64/bin; ln -sf eus irteus)
(cd /home/travis/jskeus/eus/Linux64/bin; ln -sf eusgl irteusgl)
(cd /home/travis/jskeus/eus/Linux64/bin; ln -sf eus irteus)
(cd /home/travis/jskeus/eus/Linux64/bin; ln -sf eusgl irteusgl)
cp -f irtext.l /home/travis/jskeus/eus/lib
gcc -O2 -Dx86_64 -DLinux -D_REENTRANT -DGCC -I/home/travis/jskeus/eus/include -DTHREADED -DPTHREAD  -DSVNVERSION=\"3d219f9\" -g -falign-functions=8 -fPIC -c nr.c -o /home/travis/jskeus/eus/Linux64/obj/nr.o
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-log[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-log[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7matan2[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-log[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-log[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-log[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-exponent[0;34m is assumed to be undefined function[0m
; [34;7mmanipulability[0;34m is assumed to be undefined function[0m
; [34;7msr-inverse[0;34m is assumed to be undefined function[0m
; [34;7mmatrix-determinant[0;34m is assumed to be undefined function[0m
; [34;7mm-[0;34m is assumed to be undefined function[0m
; [34;7m*keyword-package*[0;34m is assumed to be global[0m
; [34;7mouter-product-matrix[0;34m is assumed to be undefined function[0m
; [34;7minit-unit-test[0;34m is assumed to be undefined function[0m
; [34;7mrun-all-tests[0;34m is assumed to be undefined function[0m
gcc -g -c -o /home/travis/jskeus/eus/Linux64/obj/irtmodel.o -Dx86_64 -DLinux -Wimplicit -falign-functions=8 -DGCC3  -DGCC  -DTHREADED -DPTHREAD -fpic  -I/home/travis/jskeus/eus/include -O2 ./irtmodel.c; ld -shared -build-id -o /home/travis/jskeus/eus/Linux64/obj/irtmodel.so /home/travis/jskeus/eus/Linux64/obj/irtmodel.o
compiling file: ./irtgraph.l
gcc -g -c -o /home/travis/jskeus/eus/Linux64/obj/irtgraph.o -Dx86_64 -DLinux -Wimplicit -falign-functions=8 -DGCC3  -DGCC  -DTHREADED -DPTHREAD -fpic  -I/home/travis/jskeus/eus/include -O2 ./irtgraph.c; ld -shared -build-id -o /home/travis/jskeus/eus/Linux64/obj/irtgraph.so /home/travis/jskeus/eus/Linux64/obj/irtgraph.og++ -O2 -Dx86_64 -DLinux -D_REENTRANT -DGCC -I/home/travis/jskeus/eus/include -DTHREADED -DPTHREAD  -DSVNVERSION=\"3d219f9\" -g -falign-functions=8 -fPIC -g -falign-functions=8 -fPIC -c CPQP.C -o /home/travis/jskeus/eus/Linux64/obj/CPQP.o
gcc -O2 -Dx86_64 -DLinux -D_REENTRANT -DGCC -I/home/travis/jskeus/eus/include -DTHREADED -DPTHREAD  -DSVNVERSION=\"3d219f9\" -g -falign-functions=8 -fPIC -c euspqp.c -o /home/travis/jskeus/eus/Linux64/obj/euspqp.o
euspqp.c: In function 'PQPADDTRI':
euspqp.c:79:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
     int id = (int)argv[4]>>2;
              ^
euspqp.c: In function 'PQPCOLLIDE':
euspqp.c:102:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
     int flag=(int)argv[6]>>2;
              ^
/home/travis/jskeus/eus/Linux64/bin/eusx "(setq *objdir* \"/home/travis/jskeus/eus/Linux64/obj/\")" < ./compile_irtx.l > /home/travis/jskeus/eus/Linux64/obj/compile_irtx.log
rm -f /home/travis/jskeus/eus/Linux64/obj/irtx.c /home/travis/jskeus/eus/Linux64/obj/irtx.h
/home/travis/jskeus/eus/Linux64/bin/eusx "(setq *objdir* \"/home/travis/jskeus/eus/Linux64/obj/\")" < ./compile_irtimg.l > /home/travis/jskeus/eus/Linux64/obj/compile_irtimg.log
rm -f /home/travis/jskeus/eus/Linux64/obj/irtimage.c /home/travis/jskeus/eus/Linux64/obj/eusjpeg.c /home/travis/jskeus/eus/Linux64/obj/png.c /home/travis/jskeus/eus/Linux64/obj/irtimage.h /home/travis/jskeus/eus/Linux64/obj/eusjpeg.h /home/travis/jskeus/eus/Linux64/obj/png.h
/home/travis/jskeus/eus/Linux64/bin/eusx "(setq *objdir* \"/home/travis/jskeus/eus/Linux64/obj/\")" < ./compile_irtimg.l > /home/travis/jskeus/eus/Linux64/obj/compile_irtimg.log
rm -f /home/travis/jskeus/eus/Linux64/obj/irtimage.c /home/travis/jskeus/eus/Linux64/obj/eusjpeg.c /home/travis/jskeus/eus/Linux64/obj/png.c /home/travis/jskeus/eus/Linux64/obj/irtimage.h /home/travis/jskeus/eus/Linux64/obj/eusjpeg.h /home/travis/jskeus/eus/Linux64/obj/png.h
/home/travis/jskeus/eus/Linux64/bin/eusx "(setq *objdir* \"/home/travis/jskeus/eus/Linux64/obj/\")" < ./compile_irtimg.l > /home/travis/jskeus/eus/Linux64/obj/compile_irtimg.log
rm -f /home/travis/jskeus/eus/Linux64/obj/irtimage.c /home/travis/jskeus/eus/Linux64/obj/eusjpeg.c /home/travis/jskeus/eus/Linux64/obj/png.c /home/travis/jskeus/eus/Linux64/obj/irtimage.h /home/travis/jskeus/eus/Linux64/obj/eusjpeg.h /home/travis/jskeus/eus/Linux64/obj/png.h
g++ -shared -g -falign-functions=8 -Xlinker --unresolved-symbols=ignore-all -o /home/travis/jskeus/eus/Linux64/lib/libirteusx.so /home/travis/jskeus/eus/Linux64/obj/irtx.o -L/home/travis/jskeus/eus/Linux64/lib -leusgeo -L/home/travis/jskeus/eus/Linux64/lib -lnr
/usr/bin/ld: cannot find -lnr
```