### PR TITLE
Drow allow_failures for osx #507

### DIFF
--- a/.travis-osx.sh
+++ b/.travis-osx.sh
@@ -23,15 +23,7 @@ travis_time_end() {
     set -x
 }
 
-install_gnu_tools() {
-    brew install coreutils # for use GNU date command
-}
-
 setup_brew_test() {
-    travis_time_start brew.update
-    brew update
-    travis_time_end
-
     travis_time_start brew.install
     brew install euslisp/jskeus/jskeus --HEAD
     travis_time_end
@@ -43,18 +35,22 @@ setup_brew_test() {
 
 setup_make() {
     travis_time_start brew.install-deps
-    brew tap homebrew/x11
-    brew install jpeg libpng mesalib-glw wget poppler
+    brew list jpeg &>/dev/null || brew install jpeg
+    brew list libpng &>/dev/null || brew install libpng
+    brew list mesalib-glw &>/dev/null || brew install mesalib-glw
+    brew list wget &>/dev/null || brew install wget
+    brew list poppler &>/dev/null || brew install poppler
     travis_time_end
 
-    travis_time_start install.x11
-    wget http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg
-    hdiutil attach XQuartz-2.7.6.dmg
-    sudo installer -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
-    travis_time_end
+    # travis_time_start install.x11
+    # wget http://xquartz.macosforge.org/downloads/SL/XQuartz-2.7.6.dmg
+    # hdiutil attach XQuartz-2.7.6.dmg
+    # sudo installer -pkg /Volumes/XQuartz-2.7.6/XQuartz.pkg -target /
+    # travis_time_end
+    export LIBGL_ALLOW_SOFTWARE=1
 
     travis_time_start script.make
-    make -j
+    make -j 2
     travis_time_end
 
     travis_time_start script.test
@@ -67,3 +63,5 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ]; then
 else
     setup_make
 fi
+
+exit 0

--- a/.travis-osx.sh
+++ b/.travis-osx.sh
@@ -55,6 +55,7 @@ setup_make() {
 
     travis_time_start script.test
     source bashrc.eus
+    export DISPLAY=
     export EXIT_STATUS=0; for test_l in irteus/test/*.l; do irteusgl $test_l; export EXIT_STATUS=`expr $? + $EXIT_STATUS`; done;echo "Exit status : $EXIT_STATUS"; [ $EXIT_STATUS == 0 ] || exit 1
     travis_time_end
 }

--- a/.travis-osx.sh
+++ b/.travis-osx.sh
@@ -55,7 +55,7 @@ setup_make() {
 
     travis_time_start script.test
     source bashrc.eus
-    find irteus/test -iname "*.l" | xargs -n1 irteusgl
+    export EXIT_STATUS=0; for test_l in irteus/test/*.l; do irteusgl $test_l; export EXIT_STATUS=`expr $? + $EXIT_STATUS`; done;echo "Exit status : $EXIT_STATUS"; [ $EXIT_STATUS == 0 ] || exit 1
     travis_time_end
 }
 if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ]; then

--- a/.travis.sh
+++ b/.travis.sh
@@ -43,5 +43,5 @@ travis_time_end
 
 travis_time_start script.test
 source bashrc.eus
-find irteus/test -iname "*.l" | xargs -n1 irteusgl
+export EXIT_STATUS=0; for test_l in irteus/test/*.l; do irteusgl $test_l; export EXIT_STATUS=`expr $? + $EXIT_STATUS`; done;echo "Exit status : $EXIT_STATUS"; [ $EXIT_STATUS == 0 ] || exit 1
 travis_time_end

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,6 @@ matrix:
       cache: apt
       env: BUILD_DOC=true
     - os: osx
-  allow_failures:
-    - os: osx
 before_install: # Use this to prepare the system to install prerequisites or dependencies
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
   - if [[ "$DOCKER_IMAGE" == *"arm"* ]]; then mv $CI_SOURCE_PATH/irteus/test/*.l /tmp; mv /tmp/irt*.l $CI_SOURCE_PATH/irteus/test/; fi # arm VM is very slow so we do not have time to run all tests
   - if [ "$TRAVIS_OS_NAME" == "linux" -a "$BUILD_DOC" != "true" ]; then docker run --rm -i -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"; fi
   # Test installing head version jskeus via Homebrew formula
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then source $CI_SOURCE_PATH/.travis-osx.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then $CI_SOURCE_PATH/.travis-osx.sh; fi
   # Test doc generation
   - if [ "$BUILD_DOC" == "true" ]; then sudo apt-get install -y -qq git make gcc g++ libjpeg-dev libxext-dev libx11-dev libgl1-mesa-dev libglu1-mesa-dev libpq-dev libpng12-dev xfonts-100dpi xfonts-75dpi; fi
   - if [ "$BUILD_DOC" == "true" ]; then make; fi

--- a/irteus/PQP/src/PQP_Compile.h
+++ b/irteus/PQP/src/PQP_Compile.h
@@ -41,8 +41,11 @@
 #ifndef PQP_COMPILE_H
 #define PQP_COMPILE_H
 
-// prevents compiler warnings when PQP_REAL is float
+// Prevents compiler warnings when PQP_REAL is float.
+// This block is disabled on macOS clang >= 9.0.0 (e.g. High Sierra)
+// to avoid undefined exception and redefinition error.
 
+#if !defined(__APPLE__) || __clang_major__ < 9
 #include <math.h>
 #if !( (defined(__GNUC__) && (__GNUC__ >= 7) ) ) // gnu gcc 7 complains with re-definition
 inline float sqrt(float x) { return (float)sqrt((double)x); }

--- a/irteus/PQP/src/PQP_Compile.h
+++ b/irteus/PQP/src/PQP_Compile.h
@@ -43,11 +43,10 @@
 
 // Prevents compiler warnings when PQP_REAL is float.
 // This block is disabled on macOS clang >= 9.0.0 (e.g. High Sierra)
-// to avoid undefined exception and redefinition error.
+// or GNU GCC >= 7 to avoid undefined exception and redefinition error.
 
-#if !defined(__APPLE__) || __clang_major__ < 9
+#if ! ( (defined(__APPLE__) && __clang_major__ >= 9) || (defined(__GNUC__) && (__GNUC__ >= 7) ) )
 #include <math.h>
-#if !( (defined(__GNUC__) && (__GNUC__ >= 7) ) ) // gnu gcc 7 complains with re-definition
 inline float sqrt(float x) { return (float)sqrt((double)x); }
 inline float cos(float x) { return (float)cos((double)x); }
 inline float sin(float x) { return (float)sin((double)x); }


### PR DESCRIPTION
rewritten version of #507

- do not run brew update and do not install X server, because brew update
- compile all module from source and it taks more than 1 hour
- remove homebrew/x11, which is deprecated
- Drop allow_failures for osx

note that we do not able to run X app in OSX

```
[0m[32m(chessboard-30-6x5)
[0merror: xp_attach_gl_context returned: 2
X Error of failed request:  0
  Major opcode of failed request:  149 (GLX)
  Minor opcode of failed request:  26 (X_GLXMakeContextCurrent)
  Serial number of failed request:  17131
  Current serial number in output stream:  17131

```
c.f. https://api.travis-ci.org/v3/job/413395102/log.txt