### PR TITLE
Fix the compile on Debian stretch.

### DIFF
--- a/irteus/PQP/src/PQP_Compile.h
+++ b/irteus/PQP/src/PQP_Compile.h
@@ -45,7 +45,7 @@
 // This block is disabled on macOS clang >= 9.0.0 (e.g. High Sierra)
 // or GNU GCC >= 7 to avoid undefined exception and redefinition error.
 
-#if ! ( (defined(__APPLE__) && __clang_major__ >= 9) || (defined(__GNUC__) && (__GNUC__ >= 7) ) )
+#if ! ( (defined(__APPLE__) && __clang_major__ >= 9) || (defined(__GNUC__) && (__GNUC__ >= 6) ) )
 #include <math.h>
 inline float sqrt(float x) { return (float)sqrt((double)x); }
 inline float cos(float x) { return (float)cos((double)x); }


### PR DESCRIPTION
Must like the comment above says, gcc 6 on Debian
Stretch doesn't like redefining sin, cos, etc and throws
an error.  Fix this problem by not redefining on Debian Stretch.  This should fix the problems on the ROS buildfarm: http://build.ros.org/view/Mbin_ds_dS64/job/Mbin_ds_dS64__jskeus__debian_stretch_amd64__binary/72/consoleFull