### PR TITLE
[irtmodel.l]fix bug of :angle-vector for multi-dof joint

### DIFF
--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -809,12 +809,12 @@
              ;; currently only 1dof joint is supported
              (when (and (= (send j :joint-dof) 1) (= (send (send j :joint-min-max-target) :joint-dof) 1))
                ;; find index of joint-min-max-target
-               (let* ((ii 0) (jj (elt joint-list ii))
+               (let* ((ii 0) (jj (elt joint-list ii)) (ji 0)
                      tmp-joint-angle tmp-joint-min-angle tmp-joint-max-angle
                      tmp-target-joint-angle tmp-target-joint-min-angle tmp-target-joint-max-angle)
                  (while (not (eq jj (send j :joint-min-max-target)))
-                   (incf ii) (setq jj (elt joint-list ii)))
-                 (setq tmp-joint-angle (elt vec i) tmp-target-joint-angle (elt vec ii))
+                   (incf ii) (incf ji (send jj :joint-dof)) (setq jj (elt joint-list ii)))
+                 (setq tmp-joint-angle (elt vec i) tmp-target-joint-angle (elt vec ji))
                  (setq tmp-joint-min-angle (send j :joint-min-max-table-min-angle tmp-target-joint-angle)
                        tmp-joint-max-angle (send j :joint-min-max-table-max-angle tmp-target-joint-angle))
                  (setq tmp-target-joint-min-angle (send jj :joint-min-max-table-min-angle tmp-joint-angle)
@@ -844,7 +844,7 @@
                         (setq (j . joint-angle) tmp-joint-angle
                               (jj . joint-angle) tmp-target-joint-angle)
                         (setf (elt vec i) tmp-joint-angle)
-                        (setf (elt vec ii) tmp-target-joint-angle)
+                        (setf (elt vec ji) tmp-target-joint-angle)
                         )
                        );; cond
                );; let*


### PR DESCRIPTION
```:angle-vector```関数が、複数dofのjointがある場合にうまく動作しません。

下記のコードを実行したときに、```test-ok```ではmin-max-tableが正しく動作していますが、```test-bug```ではmin-max-tableが正しく動作していません。

```
(defun test-ok ()
  (setq b1 (instance bodyset-link :init (make-cascoords) :bodies (list (make-cube 30 30 30))))
  (setq b2 (instance bodyset-link :init (make-cascoords) :bodies (list (make-cube 30 30 30))))
  (setq b3 (instance bodyset-link :init (make-cascoords) :bodies (list (make-cube 30 30 30))))
  
  (setq j1 (instance rotational-joint :init :name "j1" :parent-link b1 :child-link b2 :axis :z :min -2 :max 2))
  (setq j2 (instance rotational-joint :init :name "j2" :parent-link b2 :child-link b3 :axis :z :min -2 :max 2))
  
  (send j1 :joint-min-max-target j2)
  (send j1 :joint-min-max-table (make-matrix 3 5 (list #F(-2 -1 0 1 2)
						       #F(-2 -2 -2 -2 -2)
						       #F(2 1 0 1 -2))))
  (send j2 :joint-min-max-target j1)
  (send j2 :joint-min-max-table (make-matrix 3 5 (list #F(-2 -1 0 1 2)
						       #F(-2 -2 -2 -2 -2)
						       #F(2 1 0 1 -2))))
  
  ;; instance cascaded coords
  (setq r (instance cascaded-link :init))
  (send r :assoc b1)
  (send b1 :assoc b2)
  (send b2 :assoc b3)
  (setq (r . links) (list b1 b2 b3))
  (setq (r . joint-list) (list j1 j2))
  (send r :init-ending)

  (send r :angle-vector #F(2 2))
  )

(defun test-bug ()
  (setq b0 (instance bodyset-link :init (make-cascoords) :bodies (list (make-cube 30 30 30))))
  (setq b1 (instance bodyset-link :init (make-cascoords) :bodies (list (make-cube 30 30 30))))
  (setq b2 (instance bodyset-link :init (make-cascoords) :bodies (list (make-cube 30 30 30))))
  (setq b3 (instance bodyset-link :init (make-cascoords) :bodies (list (make-cube 30 30 30))))
  
  (setq j0 (instance sphere-joint :init :name "j0" :parent-link b0 :child-link b1))
  (setq j1 (instance rotational-joint :init :name "j1" :parent-link b1 :child-link b2 :axis :z :min -2 :max 2))
  (setq j2 (instance rotational-joint :init :name "j2" :parent-link b2 :child-link b3 :axis :z :min -2 :max 2))
  
  (send j1 :joint-min-max-target j2)
  (send j1 :joint-min-max-table (make-matrix 3 5 (list #F(-2 -1 0 1 2)
						       #F(-2 -2 -2 -2 -2)
						       #F(2 1 0 1 -2))))
  (send j2 :joint-min-max-target j1)
  (send j2 :joint-min-max-table (make-matrix 3 5 (list #F(-2 -1 0 1 2)
						       #F(-2 -2 -2 -2 -2)
						       #F(2 1 0 1 -2))))
  
  ;; instance cascaded coords
  (setq r (instance cascaded-link :init))
  (send r :assoc b0)
  (send b0 :assoc b1)
  (send b1 :assoc b2)
  (send b2 :assoc b3)
  (setq (r . links) (list b0 b1 b2 b3))
  (setq (r . joint-list) (list j0 j1 j2))
  (send r :init-ending)

  (send r :angle-vector #F(3 3 3 2 2))
  )


(print (test-ok)) ;;return #F(0.976 0.976)
(print (test-bug)) ;;expected to return #F(3.0 3.0 3.0 0.976 0.976) but actually return #f(3.0 3.0 3.0 -0.1664 -0.1664)

```

この問題を修正するpull requestです。