### PR TITLE
[irteus/irtgl.l] add :string method to glviewsurface.

### DIFF
--- a/irteus/irtgl.l
+++ b/irteus/irtgl.l
@@ -212,6 +212,24 @@
      ;; transpose
      (transpose-image-rows img)
      img))
+  (:string
+   (x y str &optional (fid x:font-courb24))
+   "Draw string to irtviewer. x:font-courb24 and x::font-helvetica-bold-12 are supported for fid."
+   (send self :makecurrent)
+   (glMatrixMode GL_PROJECTION)
+   (glPushMatrix)
+   (send self :2d-mode)
+   (unless (eq (get self :glxusexfont) fid)
+     (setf (get self :glxusexfont) fid)
+     (glxUseXfont fid 32 96 (+ 1000 32)))
+   (glRasterPos2i (round x) (- (send self :height) (round y)))
+   (glListBase 1000)
+   (glCallLists (length str) GL_UNSIGNED_BYTE str)
+   (send self :3d-mode)
+   (glMatrixMode GL_PROJECTION)
+   (glPopMatrix)
+   (glMatrixMode GL_MODELVIEW)
+   )
   )
 
 (defun draw-globjects (vwr draw-things &key (clear t) (flush t) (draw-origin 150) (draw-floor nil))


### PR DESCRIPTION
Add method for drawing string. Copied from https://github.com/euslisp/EusLisp/issues/344#ref-issue-370945556

```
1.irteusgl$ (make-irtviewer)
#<x::irtviewer #X5044438 IRT viewer>
2.irteusgl$ (send *irtviewer* :viewer :viewsurface :string 100 100 "hoge")
-256
3.irteusgl$ (send *irtviewer* :viewer :viewsurface :flush)
1
```

![irtviewer-draw-string](https://user-images.githubusercontent.com/6636600/47790433-80a6a480-dd5a-11e8-8a45-37f28780bdfe.png)
