### PR TITLE
[travis-ci] fix osx compile

### DIFF
--- a/.travis-osx.sh
+++ b/.travis-osx.sh
@@ -35,6 +35,7 @@ setup_brew_test() {
 
 setup_make() {
     travis_time_start brew.install-deps
+    brew list make &>/dev/null || brew install make
     brew list jpeg &>/dev/null || brew install jpeg
     brew list libpng &>/dev/null || brew install libpng
     brew list mesalib-glw &>/dev/null || brew install mesalib-glw


### PR DESCRIPTION
broken example: 
https://travis-ci.org/euslisp/jskeus/jobs/475903847

```
######################################################################## 100.0%
==> make
Error: An exception occurred within a child process:
  NoMethodError: undefined method `undent' for #<String:0x007f97fd7123b0>
The command "if [ "$TRAVIS_OS_NAME" = "osx" ]; then $CI_SOURCE_PATH/.travis-osx.sh; fi" exited with 1.
```