### PR TITLE
[:self-collision-check] ignore links which do not have :faces

### DIFF
--- a/irteus/pqp.l
+++ b/irteus/pqp.l
@@ -35,6 +35,8 @@
    (let ((m (pqpmakemodel))
 	 vs v1 v2 v3 (id 0))
      (setf (get self :pqpmodel) m)
+     (when (null fs)
+       (return-from :make-pqpmodel m))
      (pqpbeginmodel m)
      (dolist (f fs)
        (dolist (poly (face-to-triangle-aux f))


### PR DESCRIPTION
fetchで`:self-collision-check`を行った時に、`PQP Error! EndModel() called on model with no triangles`というエラーが出ました。
調べてみると、`(send *fetch* :head_camera_rgb_frame_lk)`などのように、`:faces`がnilの`bodyset-link`クラスのインスタンスに対しては、`:make-pqpmodel`が出来ずにこのようなエラーメッセージが出るようです。

このプルリクエストでは、`:faces`がnilでないリンク同士だけをpqpの`:self-collision-check`の判定に使うようにしました。


エラー例:
```
5.irteusgl$ (send *fetch* :self-collision-check)
PQP Error! EndModel() called on model with no triangles
PQP Error! EndModel() called on model with no triangles
PQP Error! EndModel() called on model with no triangles
PQP Error! EndModel() called on model with no triangles
PQP Error! EndModel() called on model with no triangles
((#<bodyset-link #X7498cc0 base_link  0.0 0.0 0.0 / 0.0 0.0 0.0> . #<bodyset-link #X6d684b8 bellows_link2  -86.875 0.0 397.43 / 0.0 0.0 0.0>) (#<bodyset-link #X7498cc0 base_link  0.0 0.0 0.0 / 0.0 0.0 0.0> . #<bodyset-link #X6d5cd78 bellows_link  -86.875 0.0 397.43 / 0.0 0.0 0.0>) (#<bodyset-link #X712b4e0 torso_fixed_link  -86.875 0.0 377.425 / 0.0 0.0 0.0> . #<bodyset-link #X6d5d5d0 torso_lift_link  -86.875 0.0 397.43 / 0.0 0.0 0.0>) (#<bodyset-link #X712b4e0 torso_fixed_link  -86.875 0.0 377.425 / 0.0 0.0 0.0> . #<bodyset-link #X6d684b8 bellows_link2  -86.875 0.0 397.43 / 0.0 0.0 0.0>) (#<bodyset-link #X712b4e0 torso_fixed_link  -86.875 0.0 377.425 / 0.0 0.0 0.0> . #<bodyset-link #X6d5cd78 bellows_link  -86.875 0.0 397.43 / 0.0 0.0 0.0>) (#<bodyset-link #X6d684b8 bellows_link2  -86.875 0.0 397.43 / 0.0 0.0 0.0> . #<bodyset-link #X6d5cd78 bellows_link  -86.875 0.0 397.43 / 0.0 0.0 0.0>) (#<bodyset-link #X6dcab78 r_gripper_finger_link  35.009 -126.734 756.756 / 1.961 -1.492 -0.445> . #<bodyset-link #X6fa17c0 l_gripper_finger_link  65.797 -128.387 757.797 / 1.961 -1.492 -0.445>))
```