### PR TITLE
need to update longdescription

### DIFF
--- a/doc/jmanual.tex
+++ b/doc/jmanual.tex
@@ -115,14 +115,14 @@
 \newcommand{\bfx}[1]{\index{#1}{\bf #1}}
 \newcommand{\emx}[1]{\index{#1}{\em #1}}
 
-\newcommand{\longdescription}[3]{
-\index{#1}
+\newcommand{\longdescription}[4]{
+\index{#2}
 \begin{emtabbing}
-{\bf #1} 
-\it #2
-\rm
+{\bf #2} \rm \hspace{3mm} \= \`[#1] \\
+\> \it #3
 \end{emtabbing}
-\desclist{#3}
+\rm
+\desclist{#4}
 }
 
 \newcommand{\funcdesc}[3]{\functiondescription{#1}{#2}{関数}{#3}}


### PR DESCRIPTION
https://github.com/euslisp/EusLisp/commit/b6a25e96c7265d3653593a1310775f9849ff7bd7#diff-95f8abe64beb6e0fc27b68349ac0cac7 in https://github.com/euslisp/EusLisp/pull/359 changed definition of longdescription in EusLisp and we need to update this for jmanual.tex in jskeus too

Cc: @Affonso-Gui 

This PR and https://github.com/euslisp/EusLisp/pull/384 will resolve travis error on Trusty https://api.travis-ci.org/v3/job/532977689/log.txt