### PR TITLE
fix bug of extended-preview-controller

### DIFF
--- a/irteus/irtdyna.l
+++ b/irteus/irtdyna.l
@@ -1446,7 +1446,7 @@
 	   (R+btPb-1bt (m* R+btPb-1 bt))
 	   (qt (scale-matrix Q ct)))
       (dotimes (i delay)
-	(let* ((qt (if (= i (1- delay)) (m* P qt) qt))
+	(let* ((qt (if (= i (1- delay)) (m* P ct) qt))
                (fa (m* R+btPb-1 (m* bt (m* gsi qt)))))
           (setq gsi (m* A-bKt gsi))
           (dotimes (ii input-dim)

--- a/irteus/test/irteus-demo.l
+++ b/irteus/test/irteus-demo.l
@@ -89,6 +89,13 @@
   (assert
    (every #'identity (test-preview-control-0 :preview-controller-class extended-preview-controller))))
 
+(deftest test-test-extended-preview-control-0-QR
+  (assert
+   (every #'identity (mapcar #'(lambda (x y) (and (eps= (cadr (memq :zmp x)) (cadr (memq :zmp y)))
+                                                  (eps= (cadr (memq :cog x)) (cadr (memq :cog y)))))
+                             (test-preview-control-0 :preview-controller-class extended-preview-controller :q 1 :r 1e-6)
+                             (test-preview-control-0 :preview-controller-class extended-preview-controller :q 1e1 :r 1e-5)))))
+
 (deftest test-test-preview-control-1
   (assert
    (every #'identity (test-preview-control-1))))


### PR DESCRIPTION
extended-preview-cotrollerクラスの計算過程に誤りがありました。
以下の例では、
Q,Rの値がデフォルトの1.0と1e-6の場合は問題が生じませんが、
両方を1e6倍してQ,Rの値を1e6と1.0とすると、理論上はデフォルトの値の場合と同じ結果になるはずにもかかわらず、過大な制御入力が生じてIKエラーになります。

```
(load "irteus/demo/sample-robot-model.l")

(defun test-ok ()
  (setq *robot* (instance sample-robot :init))
  (send *robot* :reset-pose)
  (send *robot* :fix-leg-to-coords (make-coords))
  (objects (list *robot*))
  (send *robot* :calc-walk-pattern-from-footstep-list
        (send *robot* :go-pos-params->footstep-list
              500 150 45) ;; x[mm] y[mm] th[deg]
        :debug-view t
        :Q 1.0
        :R 1e-6
        )
  )

(defun test-bag ()
  (setq *robot* (instance sample-robot :init))
  (send *robot* :reset-pose)
  (send *robot* :fix-leg-to-coords (make-coords))
  (objects (list *robot*))
  (send *robot* :calc-walk-pattern-from-footstep-list
        (send *robot* :go-pos-params->footstep-list
              500 150 45) ;; x[mm] y[mm] th[deg]
        :debug-view t
        :Q 1e6
        :R 1.0
        )
  )

(test-ok) ;;OK
(test-bag) ;;Error inverse-kinematics failed.
```

これを修正するPRです。
計算過程についての詳細は、
https://github.com/euslisp/jskeus/pull/550
で生成されたjmanual.pdfの「18.7.1歩行動作生成」の項をご覧ください(特に式(60)のあたり)。

恐らく、
https://github.com/fkanehiro/hrpsys-base/blob/5cbb5490f55c7017f7ff789c3d9de531ba92e1b6/rtc/AutoBalancer/PreviewController.cpp#L67
も同じ問題を抱えていると思います。