### PR TITLE
add 'brew update-reset' to travis/OSX

### DIFF
--- a/.travis-osx.sh
+++ b/.travis-osx.sh
@@ -23,6 +23,12 @@ travis_time_end() {
     set -x
 }
 
+setup_brew_update() {
+    travis_time_start brew.reset
+    brew update-reset
+    travis_time_end
+}
+
 setup_brew_test() {
     travis_time_start brew.install
     brew install euslisp/jskeus/jskeus --HEAD
@@ -60,6 +66,9 @@ setup_make() {
     export EXIT_STATUS=0; for test_l in irteus/test/*.l; do irteusgl $test_l; export EXIT_STATUS=`expr $? + $EXIT_STATUS`; done;echo "Exit status : $EXIT_STATUS"; [ $EXIT_STATUS == 0 ] || exit 1
     travis_time_end
 }
+
+setup_brew_update
+
 if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ]; then
     setup_brew_test
 else


### PR DESCRIPTION
current travis OSX failing

c.f. https://travis-ci.org/euslisp/jskeus/jobs/577691109

```
/usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `require_relative': /usr/local/Homebrew/Library/Homebrew/global.rb:110: syntax error, unexpected keyword_rescue, expecting keyword_end (SyntaxError)
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `<main>'
```