### PR TITLE
add travis job to check COLLISION_LIB

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -29,6 +29,20 @@ sudo apt-get install -qq -y git make gcc g++ libjpeg-dev libxext-dev libx11-dev 
 # sudo apt-get install -qq -y texlive-latex-base ptex-bin latex2html nkf poppler-utils || echo "ok" # 16.04 does ont have ptex bin
 travis_time_end
 
+if [[ "$COLLISION_LIB" != "" ]]; then
+    travis_time_start setup.collision_lib
+
+    if [[ "$COLLISION_LIB" != "PQP" ]]; then
+        rm -fr $CI_SOURCE_PATH/irteus/PQP
+    fi
+
+    if [[ "$COLLISION_LIB" != "BULLET" ]]; then
+        dpkg -r libbullet-dev
+    fi
+
+    travis_time_end
+fi
+
 travis_time_start install # Use this to install any prerequisites or dependencies necessary to run your build
 cd ${HOME}
 ln -s $CI_SOURCE_PATH jskeus

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
     - os: linux
       env: DOCKER_IMAGE=ubuntu:bionic
     - os: linux
+      env: DOCKER_IMAGE=ubuntu:bionic COLLISION_LIB=PQP
+    - os: linux
+      env: DOCKER_IMAGE=ubuntu:bionic COLLISION_LIB=BULLET
+    - os: linux
       env: DOCKER_IMAGE=osrf/ubuntu_armhf:trusty
     - os: linux
       env: DOCKER_IMAGE=osrf/ubuntu_armhf:xenial
@@ -45,7 +49,7 @@ install:
 script:
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
   - if [[ "$DOCKER_IMAGE" == *"arm"* ]]; then COUNT=10; while [ $COUNT -gt 0 -a ! -e $CI_SOURCE_PATH/eus ] ; do echo $COUNT; sleep 1; GIT_SSL_NO_VERIFY=true git clone --depth 10 http://github.com/euslisp/EusLisp $CI_SOURCE_PATH/eus; COUNT=`expr $COUNT - 1`; done; fi # running git clone within arm VM is very slow
-  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$BUILD_DOC" != "true" ]; then docker run --rm -i -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "DOCKER_IMAGE=$DOCKER_IMAGE" -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$BUILD_DOC" != "true" ]; then docker run --rm -i -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "DOCKER_IMAGE=$DOCKER_IMAGE" -e "COLLISION_LIB=$COLLISION_LIB" -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"; fi
   # Test installing head version jskeus via Homebrew formula
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then $CI_SOURCE_PATH/.travis-osx.sh; fi
   # Test doc generation

--- a/irteus/CPQP.C
+++ b/irteus/CPQP.C
@@ -22,51 +22,93 @@
 /// above copyright notice remains intact.  
 ///
 
+#if HAVE_PQP
+#define CALL_WITH_PQP_CHECK(X) {/* X */}
+#else
+#define CALL_WITH_PQP_CHECK(X) fprintf(stderr, "jskeus is compiled without PQP because of non-free license, so you can not use function %s.\n", __PRETTY_FUNCTION__); X;
+#endif
+
+#if HAVE_PQP
+
 #include "PQP/src/PQP.h"
 #include "PQP/src/MatVec.h"
+
+#else  // HAVE_PQP
+
+#define PQP_Model void
+#define PQP_REAL double
+
+#endif // HAVE_PQP
 
 #include <stdio.h>
 extern "C"{
     
 PQP_Model *PQP_MakeModel()
 {
+#if ! HAVE_PQP
+    CALL_WITH_PQP_CHECK(return (void *)NULL);
+#else
     return new PQP_Model();
+#endif // HAVE_PQP
 }
 
 void PQP_DeleteModel(PQP_Model *m)
 {
+#if ! HAVE_PQP
+    CALL_WITH_PQP_CHECK(return;);
+#else
     delete(m);
+#endif // HAVE_PQP
 }
 
 int PQP_BeginModel(PQP_Model* m)
 {
+#if ! HAVE_PQP
+    CALL_WITH_PQP_CHECK(return 0;);
+#else
     return m->BeginModel();
+#endif // HAVE_PQP
 }
 
 int PQP_EndModel(PQP_Model* m)
 {
+#if ! HAVE_PQP
+    CALL_WITH_PQP_CHECK(return 0;);
+#else
     return m->EndModel();
+#endif // HAVE_PQP
 }
 
 int PQP_AddTri(PQP_Model *m, double p1[], double p2[], double p3[],
 		   int flag)
 {
+#if ! HAVE_PQP
+    CALL_WITH_PQP_CHECK(return 0;);
+#else
     return m->AddTri(p1, p2, p3, flag);
+#endif // HAVE_PQP
 }
 
 int PQP_Collide(double R1[3][3], double T1[3], PQP_Model *PQP_Model1,
 		double R2[3][3], double T2[3], PQP_Model *PQP_Model2,
 		int flag)
 {
+#if ! HAVE_PQP
+    CALL_WITH_PQP_CHECK(return 0;);
+#else
     PQP_CollideResult cres;
     PQP_Collide(&cres, R1, T1, PQP_Model1, R2, T2, PQP_Model2, flag);
     return cres.NumPairs();
+#endif // HAVE_PQP
 }
 
 double PQP_Distance(double R1[3][3], double T1[3], PQP_Model *PQP_Model1,
 		    double R2[3][3], double T2[3], PQP_Model *PQP_Model2,
 		    PQP_REAL *P1, PQP_REAL *P2, int qsize)
 {
+#if ! HAVE_PQP
+    CALL_WITH_PQP_CHECK(return 0.0;)
+#else
     PQP_REAL V1[3], V2[3];
     PQP_DistanceResult dres;
     PQP_Distance(&dres, R1, T1, PQP_Model1, R2, T2, PQP_Model2, 0.0, 0.0, qsize);
@@ -75,6 +117,7 @@ double PQP_Distance(double R1[3][3], double T1[3], PQP_Model *PQP_Model1,
     MxVpV(P1, R1, V1, T1);
     MxVpV(P2, R2, V2, T2);
     return (double)(dres.Distance());
+#endif // HAVE_PQP
 }
 }
 

--- a/irteus/Makefile
+++ b/irteus/Makefile
@@ -43,6 +43,13 @@ else
 endif
 $(info "--      HAVE_BULLET = ${HAVE_BULLET}")
 
+ifneq ($(wildcard PQP/*),)
+    HAVE_PQP=1
+else
+    HAVE_PQP=0
+endif
+$(info "--      HAVE_PQP = ${HAVE_PQP}")
+
 # common
 WFLAGS= #-Wall
 
@@ -50,8 +57,12 @@ BINDIR=$(EUSDIR)/$(ARCHDIR)/bin
 OBJDIR=$(EUSDIR)/$(ARCHDIR)/obj
 LIBDIR=$(EUSDIR)/$(ARCHDIR)/lib
 
-PQPLIBDIR=PQP/$(ARCHDIR)
-PQPLIB=-L$(PQPLIBDIR) -lPQP-static
+ifeq ($(HAVE_PQP), 1)
+  PQPCFLAGS=-DHAVE_PQP=$(HAVE_PQP)
+  PQPLIBDIR=PQP/$(ARCHDIR)
+  PQPLIB=-L$(PQPLIBDIR) -lPQP-static
+  PQPLIBSTATIC=PQP/$(ARCHDIR)/libPQP-static.a
+endif
 
 ifeq ($(HAVE_BULLET), 1)
   BULLETCFLAGS=`pkg-config bullet --cflags` -DHAVE_BULLET=$(HAVE_BULLET)
@@ -137,7 +148,7 @@ $(LIBIRTEUS): $(IRTEUSOBJS) $(IRTCOBJECTS) $(LIBNR)
 	$(LD) $(SOFLAGS) $(OUTOPT)$(LIBIRTEUS) $(IRTEUSOBJS) \
 		$(IRTCOBJECTS) $(IMPLIB)
 
-$(LIBIRTEUSG): $(IRTEUSGOBJS) $(IRTGCOBJECTS) $(LIBNR) PQP/$(ARCHDIR)/libPQP-static.a
+$(LIBIRTEUSG): $(IRTEUSGOBJS) $(IRTGCOBJECTS) $(LIBNR)
 	$(LD) $(SOFLAGS) $(OUTOPT)$(LIBIRTEUSG) $(IRTEUSGOBJS) \
 		$(IRTGCOBJECTS) $(IMPLIB) $(PQPLIB) $(BULLETLIB)
 
@@ -206,7 +217,7 @@ clean:
 	-rm -f $(EUSDIR)/irteus
 	-rm -f $(INSTALLOBJDIR)/compile_*.log
 	chmod a-x Makefile* *.l *.c
-	(cd PQP;make clean)
+	[ -e PQP ] && (cd PQP;make clean)
 	(cd $(EUSDIR)/lisp/image/jpeg/; make clean)
 	-rm -f $(EUSDIR)/lib/llib/pgsql.c $(EUSDIR)/lib/llib/pgsql.h
 	-rm -f $(EUSDIR)/lib/llib/time.c $(EUSDIR)/lib/llib/time.h
@@ -236,14 +247,14 @@ $(INSTALLOBJDIR)/pgsql.$(OSFX): $(EUSDIR)/lib/llib/pgsql.l
 $(INSTALLOBJDIR)/time.$(OSFX): $(EUSDIR)/lib/llib/time.l
 $(INSTALLOBJDIR)/eusjpeg.$(OSFX): $(EUSDIR)/lisp/image/jpeg/eusjpeg.l
 
-$(INSTALLOBJDIR)/irtc.$(OSFX): irtc.c $(filter-out $(INSTALLOBJDIR)/irtc.$(OSFX),$(IRTEUSOBJS) $(IRTEUSGOBJS) $(IRTGCOBJECTS) PQP/$(ARCHDIR)/libPQP-static.a $(IRTEUSXOBJS) $(INSTALLLIBDIR)/jpegmemcd.$(LSFX) $(IRTEUSIMGOBJS) $(IRTIMGCOBJECTS) $(IRTEUSGLOBJS) $(IRTGLCOBJECTS)) defun.h
+$(INSTALLOBJDIR)/irtc.$(OSFX): irtc.c $(filter-out $(INSTALLOBJDIR)/irtc.$(OSFX),$(IRTEUSOBJS) $(IRTEUSGOBJS) $(IRTGCOBJECTS) $(PQPLIBSTATIC) $(IRTEUSXOBJS) $(INSTALLLIBDIR)/jpegmemcd.$(LSFX) $(IRTEUSIMGOBJS) $(IRTIMGCOBJECTS) $(IRTEUSGLOBJS) $(IRTGLCOBJECTS)) defun.h
 	$(CC) $(CFLAGS) $(WFLAGS) -c irtc.c $(OBJOPT)$(INSTALLOBJDIR)/irtc.$(OSFX)
-$(INSTALLOBJDIR)/irtglc.$(OSFX): irtglc.c $(filter-out $(INSTALLOBJDIR)/irtglc.$(OSFX),$(IRTEUSOBJS) $(IRTEUSGOBJS) $(IRTGCOBJECTS) PQP/$(ARCHDIR)/libPQP-static.a $(IRTEUSXOBJS) $(INSTALLLIBDIR)/jpegmemcd.$(LSFX) $(IRTEUSIMGOBJS) $(IRTIMGCOBJECTS) $(IRTEUSGLOBJS) $(IRTGLCOBJECTS)) defun.h
+$(INSTALLOBJDIR)/irtglc.$(OSFX): irtglc.c $(filter-out $(INSTALLOBJDIR)/irtglc.$(OSFX),$(IRTEUSOBJS) $(IRTEUSGOBJS) $(IRTGCOBJECTS) $(PQPLIBSTATIC) $(IRTEUSXOBJS) $(INSTALLLIBDIR)/jpegmemcd.$(LSFX) $(IRTEUSIMGOBJS) $(IRTIMGCOBJECTS) $(IRTEUSGLOBJS) $(IRTGLCOBJECTS)) defun.h
 	$(CC) $(CFLAGS) $(WFLAGS) -c irtglc.c $(OBJOPT)$(INSTALLOBJDIR)/irtglc.$(OSFX)
-$(INSTALLOBJDIR)/irtgeoc.$(OSFX): irtgeoc.c $(filter-out $(INSTALLOBJDIR)/irtgeoc.$(OSFX), $(IRTEUSOBJS) $(IRTEUSGOBJS) $(IRTGCOBJECTS) PQP/$(ARCHDIR)/libPQP-static.a $(IRTEUSXOBJS) $(INSTALLLIBDIR)/jpegmemcd.$(LSFX) $(IRTEUSIMGOBJS) $(IRTIMGCOBJECTS) $(IRTEUSGLOBJS) $(IRTGLCOBJECTS)) defun.h
+$(INSTALLOBJDIR)/irtgeoc.$(OSFX): irtgeoc.c $(filter-out $(INSTALLOBJDIR)/irtgeoc.$(OSFX), $(IRTEUSOBJS) $(IRTEUSGOBJS) $(IRTGCOBJECTS) $(PQPLIBSTATIC) $(IRTEUSXOBJS) $(INSTALLLIBDIR)/jpegmemcd.$(LSFX) $(IRTEUSIMGOBJS) $(IRTIMGCOBJECTS) $(IRTEUSGLOBJS) $(IRTGLCOBJECTS)) defun.h
 	$(CC) $(CFLAGS) $(WFLAGS) -c irtgeoc.c $(OBJOPT)$(INSTALLOBJDIR)/irtgeoc.$(OSFX)
 $(INSTALLOBJDIR)/CPQP.$(OSFX): CPQP.C defun.h
-	$(CXX) $(CXXFLAGS) -c CPQP.C $(OBJOPT)$(INSTALLOBJDIR)/CPQP.$(OSFX)
+	$(CXX) $(CXXFLAGS) $(PQPCFLAGS) -c CPQP.C $(OBJOPT)$(INSTALLOBJDIR)/CPQP.$(OSFX)
 $(INSTALLOBJDIR)/euspqp.$(OSFX): euspqp.c defun.h
 	$(CC) $(CFLAGS) $(WFLAGS) -c euspqp.c $(OBJOPT)$(INSTALLOBJDIR)/euspqp.$(OSFX)
 $(INSTALLOBJDIR)/CBULLET.$(OSFX): CBULLET.cpp defun.h

--- a/irteus/Makefile
+++ b/irteus/Makefile
@@ -256,11 +256,11 @@ $(INSTALLOBJDIR)/irtgeoc.$(OSFX): irtgeoc.c $(filter-out $(INSTALLOBJDIR)/irtgeo
 $(INSTALLOBJDIR)/CPQP.$(OSFX): CPQP.C defun.h
 	$(CXX) $(CXXFLAGS) $(PQPCFLAGS) -c CPQP.C $(OBJOPT)$(INSTALLOBJDIR)/CPQP.$(OSFX)
 $(INSTALLOBJDIR)/euspqp.$(OSFX): euspqp.c defun.h
-	$(CC) $(CFLAGS) $(WFLAGS) -c euspqp.c $(OBJOPT)$(INSTALLOBJDIR)/euspqp.$(OSFX)
+	$(CC) $(CFLAGS) $(WFLAGS) $(PQPCFLAGS) -c euspqp.c $(OBJOPT)$(INSTALLOBJDIR)/euspqp.$(OSFX)
 $(INSTALLOBJDIR)/CBULLET.$(OSFX): CBULLET.cpp defun.h
 	$(CXX) $(CXXFLAGS) $(BULLETCFLAGS) -c CBULLET.cpp $(OBJOPT)$(INSTALLOBJDIR)/CBULLET.$(OSFX)
 $(INSTALLOBJDIR)/eusbullet.$(OSFX): eusbullet.c defun.h
-	$(CC) $(CFLAGS) $(WFLAGS) -c eusbullet.c $(OBJOPT)$(INSTALLOBJDIR)/eusbullet.$(OSFX)
+	$(CC) $(CFLAGS) $(WFLAGS) $(BULLETCFLAGS) -c eusbullet.c $(OBJOPT)$(INSTALLOBJDIR)/eusbullet.$(OSFX)
 $(INSTALLOBJDIR)/euspng.$(OSFX): euspng.c defun.h
 	$(CC) $(CFLAGS) $(WFLAGS) -c euspng.c $(OBJOPT)$(INSTALLOBJDIR)/euspng.$(OSFX)
 $(INSTALLOBJDIR)/nr.$(OSFX): nr.c defun.h

--- a/irteus/bullet.l
+++ b/irteus/bullet.l
@@ -30,26 +30,26 @@
 (export '(bt-collision-distance bt-collision-check))
 
 (defun bt-make-model-from-body
-    (b &key (csg (send b :csg)) (margin nil))
+    (b &key (csg (send b :csg)) (margin 0))
   "Make bullet model from body."
   (let (m)
     (cond ((assoc :sphere csg)
            (setq m
                  (btmakespheremodel
-                  (* 1e-3 (user::radius-of-sphere b)))
+                  (* 1e-3 (+ (user::radius-of-sphere b) margin)))
                  ))
           ((assoc :cube csg)
            (setq m
                  (btmakeboxmodel
-                  (* 1e-3 (user::x-of-cube b))
-                  (* 1e-3 (user::y-of-cube b))
-                  (* 1e-3 (user::z-of-cube b))
+                  (* 1e-3 (+ (user::x-of-cube b) (* margin 2)))
+                  (* 1e-3 (+ (user::y-of-cube b) (* margin 2)))
+                  (* 1e-3 (+ (user::z-of-cube b) (* margin 2)))
                   )))
           ((assoc :cylinder csg)
            (setq m
                  (btmakecylindermodel
-                  (* 1e-3 (user::radius-of-cylinder b))
-                  (* 1e-3 (user::height-of-cylinder b))
+                  (* 1e-3 (+ (user::radius-of-cylinder b) margin))
+                  (* 1e-3 (+ (user::height-of-cylinder b) margin))
                   )))
           (t
            (setq m
@@ -59,9 +59,8 @@
                                 (mapcar #'(lambda (v) (send b :inverse-transform-vector v)) (send b :vertices))))
                   (length (send b :vertices))
                   ))
+           (if (> margin 0) (btsetmargin m (* 1e-3 margin)))
            ))
-    (when margin
-      (btsetmargin m margin))
     m)
   )
 

--- a/irteus/bullet.l
+++ b/irteus/bullet.l
@@ -67,10 +67,21 @@
 
 (defmethod cascaded-coords
   (:make-btmodel
-   (&key (fat 0))
+   (&key (fat 0) ((:faces fs)))
     "Make bullet model and save pointer of the bullet model."
-   (let (vs m)
-     (cond ((derivedp self body)
+   (let (vs m v v1 v2 v3)
+     (cond (fs
+            (setq vs (flatten (send-all fs :vertices)))
+            (setq m
+                  (btmakemeshmodel
+                   (scale 1e-3 ;; [m]
+                          (apply #'concatenate float-vector
+                                 (mapcar #'(lambda (v) (send self :inverse-transform-vector v)) vs)))
+                   (length vs)
+                   ))
+            (btsetmargin m fat)
+            )
+           ((derivedp self body)
             (setq m
                   (bt-make-model-from-body self :margin fat))
             )

--- a/irteus/demo/hand-grasp-ik.l
+++ b/irteus/demo/hand-grasp-ik.l
@@ -56,7 +56,7 @@
        (setq r
              (sort
               (mapcar #'(lambda (l)
-                          (pqp-collision-distance l c0))
+                          (collision-distance l c0))
                       (flatten (link-descendants (send j :child-link))))
               #'<= #'car))
        (if (evenp (/ i 400))

--- a/irteus/demo/null-space-ik.l
+++ b/irteus/demo/null-space-ik.l
@@ -52,7 +52,7 @@
            ;; you can set optional ik convergence check by additional-check function
            :additional-check #'(lambda ()
                                  ;; calculate :inverse-kinematics-loop until collision distance becomes large enough. (> 80mm, in this case)
-                                 (let ((dist (car (pqp-collision-distance (send *robot* :rarm :elbow-p :child-link) *box*))))
+                                 (let ((dist (car (collision-distance (send *robot* :rarm :elbow-p :child-link) *box*))))
                                    (> dist 80)))
 	   )
      (send *box* :translate (float-vector 0 0 (* 7 (sin tm))))

--- a/irteus/demo/sample-arm-model.l
+++ b/irteus/demo/sample-arm-model.l
@@ -446,7 +446,7 @@
          (let (a)
            (setq a (send self :open-hand))
            (while (> a 0)
-             (if (pqp-collision-check-objects
+             (if (collision-check-objects
                   (list (send self :joint-fr :child-link)
                         (send self :joint-fl :child-link))
                   (list obj))

--- a/irteus/eusbullet.c
+++ b/irteus/eusbullet.c
@@ -121,4 +121,12 @@ pointer ___eusbullet(register context *ctx, int n, register pointer *argv)
     defun(ctx, "BTMAKEMESHMODEL", mod, BTMAKEMESHMODEL, NULL);
     defun(ctx, "BTCALCCOLLISIONDISTANCE", mod, BTCALCCOLLISIONDISTANCE, NULL);
     defun(ctx, "BTSETMARGIN", mod, BTSETMARGIN, NULL);
+
+    pointer ALGO_BULLET;
+    ALGO_BULLET=defconst(ctx,"*COLLISION-ALGORITHM-BULLET*",ALGO_BULLET,userpkg);
+#if HAVE_BULLET
+    ALGO_BULLET->c.sym.speval=defkeyword(ctx,"BULLET");
+#else
+    ALGO_BULLET->c.sym.speval=NIL;
+#endif
 }

--- a/irteus/euspqp.c
+++ b/irteus/euspqp.c
@@ -181,6 +181,14 @@ pointer ___euspqp(register context *ctx, int n, register pointer *argv)
     defun(ctx, "PQPADDTRI", mod, PQPADDTRI, NULL);
     defun(ctx, "PQPCOLLIDE", mod, PQPCOLLIDE, NULL);
     defun(ctx, "PQPDISTANCE", mod, PQPDISTANCE, NULL);
+
+    pointer ALGO_PQP;
+    ALGO_PQP=defconst(ctx,"*COLLISION-ALGORITHM-PQP*",ALGO_PQP,userpkg);
+#if HAVE_PQP
+    ALGO_PQP->c.sym.speval=defkeyword(ctx,"PQP");
+#else
+    ALGO_PQP->c.sym.speval=NIL;
+#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/irteus/irtcollision.l
+++ b/irteus/irtcollision.l
@@ -27,9 +27,8 @@
 (require :pqp)
 (require :bullet)
 
-(defconstant *collision-algorithm-pqp* :pqp)
-(defconstant *collision-algorithm-bullet* :bullet)
-(defvar *collision-algorithm* *collision-algorithm-pqp*)
+(if (and (boundp '*collision-algorithm-pqp*) (boundp '*collision-algorithm-bullet*))
+    (defvar *collision-algorithm* (or *collision-algorithm-pqp* *collision-algorithm-bullet*)))
 
 (defmethod cascaded-coords
   (:make-collisionmodel

--- a/irteus/irtcollision.l
+++ b/irteus/irtcollision.l
@@ -27,6 +27,8 @@
 (require :pqp)
 (require :bullet)
 
+;; set *collision-algorithm* from available libraries.
+;; need to cehck if *collision-algorithm-pqp*/*collision-algorithm-bullet* exists, becuase it does not defined during compile time
 (if (and (boundp '*collision-algorithm-pqp*) (boundp '*collision-algorithm-bullet*))
     (defvar *collision-algorithm* (or *collision-algorithm-pqp* *collision-algorithm-bullet*)))
 

--- a/irteus/irtcollision.l
+++ b/irteus/irtcollision.l
@@ -56,13 +56,15 @@
   )
 
 (defun collision-check
-    (model1 model2 &rest args &key &allow-other-keys)
+    (model1 model2 &rest args)
   "Check collision between model1 and model2.
    If return value is 0, no collision.
    Otherwise (return value is 1), collision."
   (cond ((eq *collision-algorithm* *collision-algorithm-pqp*)
+         (if (symbolp (car args)) (setq args (append (list geo::PQP_FIRST_CONTACT) args)))
          (apply #'pqp-collision-check model1 model2 args))
         ((eq *collision-algorithm* *collision-algorithm-bullet*)
+         (if (numberp (car args)) (setq args (cdr args)))
          (apply #'bt-collision-check model1 model2 args))
         (t
          (error "invalid collision algorithm: ~a~%" *collision-algorithm*)))

--- a/irteus/irtmodel.l
+++ b/irteus/irtmodel.l
@@ -778,8 +778,8 @@
      (send (send j :parent-link) :add-child-links (send j :child-link))
      )
    (send self :update-descendants)
-   ;; Make default collision shape by pqp
-   (dolist (l (send self :links)) (send l :make-pqpmodel))
+   ;; Make default collision shape
+   (dolist (l (send self :links)) (send l :make-collisionmodel))
    )
   (:links (&rest args) "Returns links, or args is passed to links" (user::forward-message-to-all links args))
   (:joint-list (&rest args) "Returns joint list, or args is passed to joints" (user::forward-message-to-all joint-list args))
@@ -917,7 +917,7 @@
      (when overwrite-collision-model
        (setf (get l0 :pqpmodel) nil)    
        (setf (get l1 :pqpmodel) nil)
-       (pqp-collision-check l0 l1 geo::PQP_FIRST_CONTACT :fat fat :fat2 fat2))
+       (collision-check l0 l1 geo::PQP_FIRST_CONTACT :fat fat :fat2 fat2))
 
      (send self :make-min-max-table-using-collision-check
            l0 l1 joint0 joint1 joint-range0 joint-range1 min-joint0 min-joint1 fat fat2 debug margin)
@@ -949,7 +949,7 @@
                   ((and (eq flag :free) (/= (mod i skip-count) 0) (<= i (- joint-range0 skip-count)))
                    (setq c t))
                   (t
-                   (setq c (= (pqp-collision-check l0 l1 geo::PQP_FIRST_CONTACT :fat fat :fat2 fat2) 0))
+                   (setq c (= (collision-check l0 l1 geo::PQP_FIRST_CONTACT :fat fat :fat2 fat2) 0))
                    (cond 
                     ((and (eq flag :low-limit) c) 
                      (setq flag :free))
@@ -1327,7 +1327,7 @@
 	     (setf (elt col-list i) nil)
 	     )
 	 (progn
-	   (setq np (nconc (pqp-collision-distance (car pair) (cadr pair) :qsize 2) (list (float-vector 0 0 0) i)))
+	   (setq np (nconc (collision-distance (car pair) (cadr pair) :qsize 2) (list (float-vector 0 0 0) i)))
 	   (if (<= (car np) distance-limit)
 	       (progn
 		 (if (and warnp (< (car np) 1.0))
@@ -2660,7 +2660,7 @@
        )
      pairs))
   (:self-collision-check
-   (&key (mode :all) (pairs (send self :collision-check-pairs)) (collision-func 'pqp-collision-check))
+   (&key (mode :all) (pairs (send self :collision-check-pairs)) (collision-func 'collision-check))
    (let ((cpairs) (col-count 0))
      (dolist (p pairs)
        (let ((colp (/= (funcall collision-func (car p) (cdr p)) 0)))

--- a/irteus/irtsensor.l
+++ b/irteus/irtsensor.l
@@ -58,7 +58,7 @@
      (setq
       data
       (if (some #'(lambda (obj)
-                    (setq r (car (pqp-collision-distance self obj)))
+                    (setq r (car (collision-distance self obj)))
                     (< r bumper-threshold)) objs) 1 0))))
   (:draw (vwer) (send self :draw-sensor vwer))
   (:draw-sensor

--- a/irteus/test/irteus-demo.l
+++ b/irteus/test/irteus-demo.l
@@ -34,6 +34,26 @@
 (deftest test-particle
   (particle))
 
+(load "models/darwin.l")
+;; use :make-collisionmdoel for euscollada-robot, use darwin-robot to override
+(defmethod darwin-robot
+  ;; make collision model from faces or gl-vertices
+  (:make-collision-model-for-links
+   (&key (fat 0) ((:links ls) (send self :links)))
+   (dolist (ll ls)
+     (send ll :make-collisionmodel
+             :fat fat
+             :faces (flatten (mapcar #'(lambda (x)
+                                         (cond
+                                          ((find-method x :def-gl-vertices)
+                                           (send (x . glvertices) :convert-to-faces :wrt :world))
+                                          (t
+                                           (send x :faces))))
+                                     (send ll :bodies)))))
+   )
+  )
+
+
 ;; check whether all ik are solved for walking examples
 (deftest test-walk-motion-for-sample-robot
   (assert

--- a/irteus/test/test-collision.l
+++ b/irteus/test/test-collision.l
@@ -96,6 +96,59 @@
      )
     ))
 
+(defun test-collision-distance
+    (obj1 obj2)
+  (let* ((bbox-radius
+          (elt (v- (send (send obj1 :box) :center) (send (send obj1 :box) :minpoint)) 1))
+         (cnt 0)
+         (dist)
+         (approx-dist-min)
+         (approx-dist-max)
+         (ret1) (ret2) (ret3)
+         )
+    (send obj1 :set-color (float-vector 1 0 0) 0.5)
+    (send obj2 :set-color (float-vector 0 1 0) 0.4)
+    (objects (list obj1 obj2))
+    (do-until-key
+     ;; move object
+     (incf cnt)
+     (send obj1 :newcoords
+           (make-coords :pos (float-vector (* 300.0 (sin (/ cnt 20.0))) 50 0)))
+     (send obj1 :worldcoords)
+     (send *irtviewer* :draw-objects)
+     ;; get pqp/bullet distance
+     ;; PQP requries geo::PQP_FIRST_CONTACT, where as bullet does not need this
+     (setf (get obj1 :pqpmodel) nil) (setf (get obj1 :btmodel) nil) ;; clear cache
+     (setf (get obj2 :pqpmodel) nil) (setf (get obj2 :btmodel) nil)
+     (setq ret1 (collision-check obj1 obj2 geo::PQP_FIRST_CONTACT))
+     (setf (get obj1 :pqpmodel) nil) (setf (get obj1 :btmodel) nil) ;; clear cache
+     (setf (get obj2 :pqpmodel) nil) (setf (get obj2 :btmodel) nil)
+     (setq ret2 (collision-check obj1 obj2))
+     (setf (get obj1 :pqpmodel) nil) (setf (get obj1 :btmodel) nil) ;; clear cache
+     (setf (get obj2 :pqpmodel) nil) (setf (get obj2 :btmodel) nil)
+     (send obj1 :make-collisionmodel :faces (send obj1 :faces))
+     (send obj2 :make-collisionmodel :faces (send obj2 :faces))
+     (setq ret3 (collision-check obj1 obj2))
+     (assert (and (eq ret1 ret2) (eq ret1 ret3)))
+     ;; get approximate distance and compare
+     (setq approx-dist-max
+           (norm (v- (send (send obj1 :box) :center) (send (send obj2 :box) :center))))
+     (setq approx-dist-min
+           (- approx-dist-max (+ bbox-radius bbox-radius)))
+     ;(format t "ret: ~A/~A/~A dist-min: ~A, (~A ~A)~%" ret1 ret2 ret3 approx-dist-min (> ret1 0) (< approx-dist-min 0))
+     (assert (or (and (> ret1 0) (< approx-dist-min 5))
+                 (and (= ret1 0) (> approx-dist-min -5))))
+     ;; draw
+     (when (> ret1 0)
+       (send obj1 :draw-on :flush nil :width 16 :color (float-vector 1 0.4 0.4))
+       (send obj2 :draw-on :flush nil :width 16 :color (float-vector 0.4 1 0.4)))
+     (send *irtviewer* :viewer :flush)
+     (unix::usleep (* 20 1000))
+     (when (> cnt 100)
+       (return-from nil nil))
+     )
+    ))
+
 (when *collision-algorithm-pqp*
 
 (deftest test-collision-sphere-analytical-pqp
@@ -121,6 +174,12 @@
    (make-cone (float-vector 0 0 200) (list (float-vector -200 -200 0) (float-vector 200 -200 0) (float-vector 0 250 0))) ;; cone is treated as mesh
    (make-cube 200 200 300))
   )
+
+(deftest test-collision-distance-pqp
+  (select-collision-algorithm *collision-algorithm-pqp*)
+  (test-collision-distance
+   (make-cube 200 200 200)
+   (make-cube 200 200 200)))
 
 )
 
@@ -149,6 +208,12 @@
    (make-cone (float-vector 0 0 200) (list (float-vector -200 -200 0) (float-vector 200 -200 0) (float-vector 0 250 0))) ;; cone is treated as mesh
    (make-cube 200 200 300))
   )
+
+(deftest test-collision-distance-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-distance
+   (make-cube 200 200 200)
+   (make-cube 200 200 200)))
 
 )
 

--- a/irteus/test/test-collision.l
+++ b/irteus/test/test-collision.l
@@ -180,7 +180,7 @@
         (cond ((< (- dist dist-fat) (* fat 1.5)) 3)
               (t 2))
         "distance between objects ~7,3f ~7,3f ~7,3f~%" (- dist dist-fat ) dist dist-fat)
-       (assert (< (* fat 1.1) (- dist dist-fat) (* fat 2.1))))
+       (assert (< (* fat 1.05) (- dist dist-fat) (* fat 2.1))))
      ;;
      (send (elt ret2 1) :draw-on :flush nil :width 8 :size 50 :color (float-vector 1 0.4 0.4))
      (send (elt ret2 2) :draw-on :flush nil :width 8 :size 50 :color (float-vector 0.4 1 0.4))

--- a/irteus/test/test-collision.l
+++ b/irteus/test/test-collision.l
@@ -50,16 +50,6 @@
      )
     ))
 
-(deftest test-collision-sphere-analytical-pqp
-  (select-collision-algorithm *collision-algorithm-pqp*)
-  (test-collision-sphere-analytical)
-  )
-
-(deftest test-collision-sphere-analytical-bullet
-  (select-collision-algorithm *collision-algorithm-bullet*)
-  (test-collision-sphere-analytical)
-  )
-
 (defun test-collision-object-approx
     (obj1 obj2)
   (let* ((bbox-radius1
@@ -106,26 +96,21 @@
      )
     ))
 
+(when *collision-algorithm-pqp*
+
+(deftest test-collision-sphere-analytical-pqp
+  (select-collision-algorithm *collision-algorithm-pqp*)
+  (test-collision-sphere-analytical)
+  )
+
 (deftest test-collision-cube-approx-pqp
   (select-collision-algorithm *collision-algorithm-pqp*)
   (test-collision-object-approx
    (make-cube 100 150 200) (make-cube 200 200 300))
   )
 
-(deftest test-collision-cube-approx-bullet
-  (select-collision-algorithm *collision-algorithm-bullet*)
-  (test-collision-object-approx
-   (make-cube 100 150 200) (make-cube 200 200 300))
-  )
-
 (deftest test-collision-cylinder-approx-pqp
   (select-collision-algorithm *collision-algorithm-pqp*)
-  (test-collision-object-approx
-   (make-cylinder 100 200) (make-cube 200 200 300))
-  )
-
-(deftest test-collision-cylinder-approx-bullet
-  (select-collision-algorithm *collision-algorithm-bullet*)
   (test-collision-object-approx
    (make-cylinder 100 200) (make-cube 200 200 300))
   )
@@ -137,12 +122,35 @@
    (make-cube 200 200 300))
   )
 
+)
+
+(when *collision-algorithm-bullet*
+
+(deftest test-collision-sphere-analytical-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-sphere-analytical)
+  )
+
+(deftest test-collision-cube-approx-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-object-approx
+   (make-cube 100 150 200) (make-cube 200 200 300))
+  )
+
+(deftest test-collision-cylinder-approx-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-object-approx
+   (make-cylinder 100 200) (make-cube 200 200 300))
+  )
+
 (deftest test-collision-mesh-approx-bullet
   (select-collision-algorithm *collision-algorithm-bullet*)
   (test-collision-object-approx
    (make-cone (float-vector 0 0 200) (list (float-vector -200 -200 0) (float-vector 200 -200 0) (float-vector 0 250 0))) ;; cone is treated as mesh
    (make-cube 200 200 300))
   )
+
+)
 
 (eval-when (load eval)
   (run-all-tests)

--- a/irteus/test/test-collision.l
+++ b/irteus/test/test-collision.l
@@ -149,6 +149,51 @@
      )
     ))
 
+(defun test-collision-distance-fat
+    (obj1 obj2 &optional (fat 25))
+  (let* ((cnt 0) dist dist-fat ret ret-fat)
+    (send obj1 :set-color (float-vector 1 0 0) 0.5)
+    (send obj2 :set-color (float-vector 0 1 0) 0.4)
+    (objects (list obj1 obj2))
+    (do-until-key
+     ;; move object
+     (incf cnt)
+     (send obj1 :newcoords
+           (make-coords :pos (float-vector (* 750.0 (sin (/ cnt 20.0))) 50 0)))
+     ;; do not rotate on cube, otherwise the distance with margin becomes very complex
+     (unless (assoc :cube (send obj1 :csg))
+       (send obj1 :rpy (* pi (sin (/ cnt 200.0))) (+ (* pi (sin (/ cnt 400.0))) pi/2) 0))
+     (send obj1 :worldcoords)
+     (send *irtviewer* :draw-objects)
+     ;; get pqp/bullet distance
+     ;; PQP requries geo::PQP_FIRST_CONTACT, where as bullet does not need this
+     (setf (get obj1 :pqpmodel) nil) (setf (get obj1 :btmodel) nil) ;; clear cache
+     (setf (get obj2 :pqpmodel) nil) (setf (get obj2 :btmodel) nil)
+     (setq ret1 (collision-distance obj1 obj2))
+     (setf (get obj1 :pqpmodel) nil) (setf (get obj1 :btmodel) nil) ;; clear cache
+     (setf (get obj2 :pqpmodel) nil) (setf (get obj2 :btmodel) nil)
+     (setq ret2 (collision-distance obj1 obj2 :fat fat))
+     ;; check if fat works
+     (setq dist (elt ret1 0) dist-fat (elt ret2 0))
+     (when (and (eps> dist 0.0) (eps> dist-fat 0.0)) ;; when collide
+       (warning-message
+        (cond ((< (- dist dist-fat) (* fat 1.5)) 3)
+              (t 2))
+        "distance between objects ~7,3f ~7,3f ~7,3f~%" (- dist dist-fat ) dist dist-fat)
+       (assert (< (* fat 1.1) (- dist dist-fat) (* fat 2.1))))
+     ;;
+     (send (elt ret2 1) :draw-on :flush nil :width 8 :size 50 :color (float-vector 1 0.4 0.4))
+     (send (elt ret2 2) :draw-on :flush nil :width 8 :size 50 :color (float-vector 0.4 1 0.4))
+     (send (make-line (elt ret2 1) (elt ret2 2)) :draw-on :flush nil
+           :width 8 :color (if (> (elt ret2 0) 0) (float-vector 0 1 1) (float-vector 1 1 0)))
+     (send *irtviewer* :viewer :flush)
+     (x::window-main-one)
+     (unix::usleep (* 20 1000))
+     (when (> cnt 100)
+       (return-from nil nil))
+     )
+    ))
+
 (when *collision-algorithm-pqp*
 
 (deftest test-collision-sphere-analytical-pqp
@@ -181,6 +226,29 @@
    (make-cube 200 200 200)
    (make-cube 200 200 200)))
 
+(deftest test-collision-distance-cube-pqp
+  (select-collision-algorithm *collision-algorithm-pqp*)
+  (test-collision-distance-fat
+   (make-cube 200 300 200)
+   (make-cube 200 200 200)))
+
+(deftest test-collision-distance-cylinder-pqp
+  (select-collision-algorithm *collision-algorithm-pqp*)
+  (test-collision-distance-fat
+   (make-cube 200 300 200)
+   (make-cylinder 100 200)))
+
+(deftest test-collision-distance-sphere-pqp
+  (select-collision-algorithm *collision-algorithm-pqp*)
+  (test-collision-distance-fat
+   (make-sphere 200)
+   (make-sphere 200)))
+
+(deftest test-collision-distance-mesh-pqp
+  (select-collision-algorithm *collision-algorithm-pqp*)
+  (test-collision-distance-fat
+   (body+ (make-cube 200 200 100) (make-cube 100 100 300))
+   (body+ (make-cube 200 200 100) (make-cube 100 100 300))))
 )
 
 (when *collision-algorithm-bullet*
@@ -214,6 +282,30 @@
   (test-collision-distance
    (make-cube 200 200 200)
    (make-cube 200 200 200)))
+
+(deftest test-collision-distance-cube-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-distance-fat
+   (make-cube 200 300 200)
+   (make-cube 200 200 300)))
+
+(deftest test-collision-distance-cylinder-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-distance-fat
+   (make-cube 200 300 200)
+   (make-cylinder 100 200)))
+
+(deftest test-collision-distance-sphere-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-distance-fat
+   (make-sphere 200)
+   (make-sphere 200)))
+
+(deftest test-collision-distance-mesh-bullet
+  (select-collision-algorithm *collision-algorithm-bullet*)
+  (test-collision-distance-fat
+   (body+ (make-cube 200 200 100) (make-cube 100 100 300))
+   (body+ (make-cube 200 200 100) (make-cube 100 100 300))))
 
 )
 


### PR DESCRIPTION
rewrited version of #555 and #538
- Add eusbullet for using bullet collision function 
- add `irtcollada.l`. Users are expected to use `collision-*` functions instead of `pqp-collision-*
```
(:make-collisionmodel <= (:make-pqpmodel
(collision-distance)      <= (pqp-colision-distnace)
(collision-check)          <= (pqp-collision-check)
(collision-check-objects) <= (pqp-collision-check-objects)
```

you can selesct collision libraries by
```
  (select-collision-algorithm *collision-algorithm-pqp*)
```
or
```
  (select-collision-algorithm *collision-algorithm-bullet*)
```