### PR TITLE
add irteus man pages

### DIFF
--- a/doc/irteus.1
+++ b/doc/irteus.1
@@ -1,0 +1,30 @@
+.TH irteus 1 "May/15/2020"
+.SH NAME
+irteusg \- EusLisp/irteus
+.SH SYNOPSIS
+.nf
+irteus [start-up-files]
+irteusgl
+.fi
+.SH DESCRIPTION
+irteus is Lisp based intelligent robots programming system, writtin
+based on EusLisp, an object-based implementation of CommonLisp with
+geometric modeling facilities.
+irteus is the basic and lightest version of irteus and irteusgl has
+window interface with XLib and OpenGL
+
+ 
+.SH FILES
+Source programs should be stored under /usr/share/euslisp/jskeus.
+The name of this installation directory is held in *eusdir*/jskeus variable
+in EusLisp and referenced by \fBload\fR.
+
+.nf
+/usr/bin/	architecture (and OS) dependent executables
+*eusdir*/irteus/	jskeus libraries
+*eusdir*/irteus/demo	demonstration programs
+
+.SH SEE ALSO
+Object-Based Robot Programming System EusLisp, Reference Manual
+
+


### PR DESCRIPTION
add irteus man pages

```
irteus(1)                  General Commands Manual                  irteus(1)

NAME
       irteusg - EusLisp/irteus

SYNOPSIS
       irteus [start-up-files]
       irteusgl

DESCRIPTION
       irteus  is  Lisp  based intelligent robots programming system, writtin
       based on EusLisp, an object-based implementation  of  CommonLisp  with
       geometric  modeling facilities.  irteus is the basic and lightest ver‐
       sion of irteus and irteusgl has window interface with XLib and OpenGL

FILES
       Source programs should be stored under /usr/share/euslisp/jskeus.  The
       name  of  this installation directory is held in *eusdir*/jskeus vari‐
       able in EusLisp and referenced by load.

       /usr/bin/ architecture (and OS) dependent executables
       *eusdir*/irteus/    jskeus libraries
       *eusdir*/irteus/demo     demonstration programs

SEE ALSO
       Object-Based Robot Programming System EusLisp, Reference Manual

                                 May/15/2020                        irteus(1)

```