### PR TITLE
[irtrobot.l] fix bug in :calc-zmp-from-forces-moments

### DIFF
--- a/irteus/irtrobot.l
+++ b/irteus/irtrobot.l
@@ -594,7 +594,7 @@
                                       (find-if #'(lambda (l) (equal fs (car (send self l :force-sensors)))) '(:rleg :lleg)))
                                   (send self :force-sensors)))
             '(:rleg :lleg)))
-         (force-sensors (mapcar #'(lambda (l) (send self :force-sensor l)) limbs))
+         (force-sensors (mapcar #'(lambda (l) (car (send self l :force-sensors))) limbs))
          (cop-coords (mapcar #'(lambda (l) (send self l :end-coords)) limbs))
          (fz-thre 1e-3) ;; [N]
          (limb-cop-fz-list


### PR DESCRIPTION
```
(load "package://euslisp/jskeus/irteus/demo/sample-robot-model.l")
(setq *robot* (instance sample-robot :init))
(send *robot* :calc-zmp-from-forces-moments (list #F(0 0 500) #F(0 0 500)) (list #F(0 0 0) #F(0 0 0)))
```
上記プログラムを実行すると，以下のエラーが出ました．
```
error: cannot find method :worldpos in (send fs :worldpos) 
```
これを直すPull Requestです．