### PR TITLE
use gcc -dumpmachine

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -25,8 +25,8 @@ jobs:
           - DOCKER_IMAGE: osrf/ubuntu_armhf:xenial
           - DOCKER_IMAGE: osrf/ubuntu_arm64:trusty
           - DOCKER_IMAGE: osrf/ubuntu_arm64:xenial
-          - DOCKER_IMAGE: osrf/ubuntu_arm64:bionic
-          - DOCKER_IMAGE: osrf/ubuntu_arm64:focal
+          - DOCKER_IMAGE: arm64v8/ubuntu:bionic
+          - DOCKER_IMAGE: arm64v8/ubuntu:focal
           - DOCKER_IMAGE: osrf/debian_arm64:stretch
       fail-fast: false
 
@@ -48,8 +48,9 @@ jobs:
           export TRAVIS_OS_NAME=linux
           export DOCKER_IMAGE=${{matrix.DOCKER_IMAGE}}
           if [[ "$DOCKER_IMAGE" == *"arm"* ]]; then sudo apt-get install -y -qq qemu-user-static git; fi
+          if [[ "$DOCKER_IMAGE" == *"arm64v8"* ]]; then export QEMU_VOLUME="-v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static"; fi #
           echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-          docker run --rm -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "DOCKER_IMAGE=$DOCKER_IMAGE" -e "COLLISION_LIB=$COLLISION_LIB" -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"
+          docker run --rm $QEMU_VOLUME -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "DOCKER_IMAGE=$DOCKER_IMAGE" -e "COLLISION_LIB=$COLLISION_LIB" -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"
 
   doc:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ ifneq ($(GCC_MACHINE),)
  ifeq ($(GCC_MACHINE),i686-linux-gnu)
    MACHINE=x86
  endif
+ ifeq ($(GCC_MACHINE),aarch64-linux-gnu)
+   MACHINE=aarch64
+ endif
+ ifeq ($(GCC_MACHINE),arm-linux-gnueabihf)
+   MACHINE=arm
+ endif
 endif
 ifeq ($(MACHINE),)
  MACHINE=$(shell uname -m)
@@ -26,7 +32,7 @@ ifeq ($(OS),Linux)
   export ARCHDIR=Linux64
   export MAKEFILE=Makefile.Linux64
  else
- ifneq (, $(findstring armv,$(MACHINE)))
+ ifneq (, $(findstring arm,$(MACHINE)))
   export ARCHDIR=LinuxARM
   export MAKEFILE=Makefile.LinuxARM
  else ifneq (, $(findstring aarch,$(MACHINE)))

--- a/irteus/Makefile.Linux
+++ b/irteus/Makefile.Linux
@@ -72,7 +72,7 @@ CXXFLAGS=$(CFLAGS)
 CFLAGS+= -g -falign-functions=4
 CXXFLAGS+=-g -falign-functions=4
 
-ifeq ($(shell /bin/uname -m), x86_64)
+ifeq ($(shell gcc -dumpmachine), x86_64-linux-gnu)
 CC += -m32
 CXX += -m32
 LD += -m32

--- a/irteus/Makefile.LinuxARM
+++ b/irteus/Makefile.LinuxARM
@@ -63,7 +63,8 @@ FFTW=-L/usr/local/lib -lfftw -lrfftw
 
 SVNVERSION=\"$(shell git rev-parse --short HEAD)\"
 
-MACHINE=$(shell uname -m | sed 's/\(armv[0-9]\).*/\1/')
+# gcc -dumpmachine retruns target triplet consists of three fields separated by a hyphen (-).
+MACHINE=$(shell gcc -dumpmachine | sed 's/\(.*\)-.*-.*/\1/')
 THREAD= -DTHREADED -DPTHREAD
 
 CFLAGS=-O2 -D$(MACHINE) -D$(ARCH) -DLinux -DARM -D_REENTRANT -DGCC -I$(EUSDIR)/include $(THREAD) -DSVNVERSION=$(SVNVERSION) -fPIC

--- a/irteus/PQP/Makefile.Linux
+++ b/irteus/PQP/Makefile.Linux
@@ -10,7 +10,7 @@ LPFX = lib
 LIBS = -L$(ARCHDIR) -lRAPID 
 
 
-ifeq ($(shell /bin/uname -m), x86_64)
+ifeq ($(shell gcc -dumpmachine), x86_64-linux-gnu)
 CC += -m32 
 LD += -m32
 EXELD += -m32 


### PR DESCRIPTION
 , instead of uname -m beacuase uname -m returns host architecutre within docker environment so if you run arm7v compile on docker/arm64, it returns aarch64, that confusis ros build farm https://build.ros.org/job/Nbin_ufhf_uFhf__euslisp__ubuntu_focal_armhf__binary/