### PR TITLE
add write-to-png in irtgraph

### DIFF
--- a/irteus/irtgraph.l
+++ b/irteus/irtgraph.l
@@ -351,7 +351,22 @@ Args:
          ;; fname finished with '.pdf', remove it
          (setq fname (subseq str 0 (1- (length str))))
          )))
-   (send self :write-to-file fname result-path title))
+   (send self :write-to-file fname result-path title "pdf"))
+  (:write-to-png (fname &optional result-path
+                        (title (string-right-trim ".png" fname)))
+   "write graph structure to png
+Args:
+  fname: filename for output
+  result-path: list of solver-node, it's result of (send solver :solve graph)
+  title: title of graph
+"
+   (when (substringp ".png" fname)
+     (let ((str (string-right-trim "png" fname)))
+       (when (= (elt str (1- (length str))) #\.)
+         ;; fname finished with '.png', remove it
+         (setq fname (subseq str 0 (1- (length str))))
+         )))
+   (send self :write-to-file fname result-path title "png"))
   (:original-draw-mode ()
    "change draw-mode to original mode"
    (send self :draw-both-arc nil)

--- a/irteus/test/graph.l
+++ b/irteus/test/graph.l
@@ -267,6 +267,10 @@
     ;; write graph to pdf file
     (warning-message 2 "write to /tmp/robots_in_jsk.pdf~%")
     (send g :write-to-pdf "/tmp/robots_in_jsk.pdf" nil "robots_in_jsk")
+
+    ;; write graph to png file
+    (warning-message 2 "write to /tmp/robots_in_jsk.png~%")
+    (send g :write-to-png "/tmp/robots_in_jsk.png" nil "robots_in_jsk")
     g))
 
 (eval-when (load eval)


### PR DESCRIPTION
I add `write-to-png` method in `irtgraph`.
You can get png image of graph structure by running `(send gr :write-to-png "graph.png")`.