### PR TITLE
png: enable to write transparent image with :background

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -85,6 +85,9 @@ for test_l in irteus/test/*.l; do
 
     # osrf/ubuntu_arm64:trusty takes >50 min, skip irteus-demo.l
     [[ "$DOCKER_IMAGE" == *"arm64:trusty"* && $test_l =~ irteus-demo.l ]] && continue;
+    # arm64v8/ubuntu:focal takes >50 min, skip transport.l
+    [[ "$DOCKER_IMAGE" == "arm64v8/ubuntu:focal" && $test_l =~ transparent.l ]] && continue;
+
     # skip collision test because bullet of 2.83 or later version is not released in trusty and jessie.
     # https://github.com/euslisp/jskeus/blob/6cb08aa6c66fa8759591de25b7da68baf76d5f09/irteus/Makefile#L37
     [[ ( "$DOCKER_IMAGE" == *"trusty"* || "$DOCKER_IMAGE" == *"jessie"* ) && $test_l =~ test-collision.l ]] && continue;
@@ -101,6 +104,8 @@ for test_l in irteus/test/*.l; do
     export EXIT_STATUS=`expr $TMP_EXIT_STATUS + $EXIT_STATUS`;
 
     travis_time_end `expr 32 - $TMP_EXIT_STATUS`
+
+    [[ "$DOCKER_IMAGE" == "arm64v8/ubuntu:focal" ]] && continue;
 
     travis_time_start jskeus.compiled.${test_l##*/}.test
 

--- a/irteus/irtimage.l
+++ b/irteus/irtimage.l
@@ -61,14 +61,14 @@
    (t (warn ";; Could not find file ~A~%" fname)
       (return-from read-image-file nil))))
 
-(defun write-image-file (fname img)
+(defun write-image-file (fname img &optional background)
   "write img to given fname"
   (cond
    ((or (string= (pathname-type fname) "jpg")
         (string= (pathname-type fname) "jpeg"))
     (write-jpeg-file fname img))
    ((string= (pathname-type fname) "png")
-    (write-png-file fname img))
+    (write-png-file fname img background))
    (t
     (write-pnm-file fname img))))
 

--- a/irteus/irtviewer.l
+++ b/irteus/irtviewer.l
@@ -534,12 +534,14 @@
                         (t "000000")))
      ))
   (:save-image
-   (filename)
-   "save curent view to image, supported formats are jpg/png/pnm"
+   (filename &key background)
+   "save curent view to image, supported formats are jpg/png/pnm,
+    png supports transparent image with background. To use this feature, set :change-background #f(0 1 0) and specify #f(0 1 0) as background"
    (user::write-image-file filename
                            (send viewer :viewsurface :getglimage
                                  :width (- (send viewer :viewsurface :width) 1)
-                                 :height (send viewer :viewsurface :height))))
+                                 :height (send viewer :viewsurface :height))
+                           background))
   )
 
 (defun draw-things (objs)

--- a/irteus/png.l
+++ b/irteus/png.l
@@ -62,14 +62,15 @@
         img)
     nil))
 
-(defun write-png-file (fname img)
+(defun write-png-file (fname img &optional background)
   (let (byte-depth)
     (cond
      ((derivedp img grayscale-image) (setq byte-depth 1))
      ((derivedp img color-image24) (setq byte-depth (send img :byte-depth)))
      (t (error ";; write-png-file: unsupported image type ~A" img)))
   (png-write-image fname (send img :width) (send img :height) byte-depth
-                   (send img :entity))
+                   (send img :entity) background
+                   )
   ))
 
 (provide :png "@(#)$Id$")


### PR DESCRIPTION
you can write png image with transparent background by
```
(send *irtviewer* :change-background #f(1 0 0))
(send *irtviewer* :draw-objects)
(send *irtviewer* :save-image "test.png" :background #f(1 0 0))

```

see https://gist.github.com/k-okada/d702a5a63fcf24d8be03de680f8a5e76 for example



![test](https://user-images.githubusercontent.com/493276/228212994-1c30585d-d939-4059-b8ec-4711328e388c.png)
![test-bone](https://user-images.githubusercontent.com/493276/228212999-bbf23e95-44bf-4bae-a777-17466dfe2376.png)
![test-hid](https://user-images.githubusercontent.com/493276/228213003-1d5be325-6f5b-46f3-a2c1-11f69129947b.png)
