### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -54,10 +54,22 @@ jobs:
 
   catkin:
     runs-on: ubuntu-latest
-    container: ubuntu:18.04
+    container:
+      image: ubuntu:18.04
+      volumes:
+        - /tmp/node20:/__e/node20
     timeout-minutes: 60
 
     steps:
+      - name: Try to replace `node` with an glibc 2.17
+        shell: bash
+        run: |
+          ls -lar /__e/node20 &&
+          apt-get install -y curl &&
+          curl -Lo /tmp/node.tar.gz https://unofficial-builds.nodejs.org/download/release/v20.17.0/node-v20.17.0-linux-x64-glibc-217.tar.gz &&
+          cd /__e/node20 &&
+          tar -x --strip-components=1 -f /tmp/node.tar.gz &&
+          ls -lar /__e/node20/bin/
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Apt

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -153,7 +153,7 @@ jobs:
 
 
   osx:
-    runs-on: macos-latest
+    runs-on: macos-13  # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -48,9 +48,9 @@ jobs:
           export TRAVIS_OS_NAME=linux
           export DOCKER_IMAGE=${{matrix.DOCKER_IMAGE}}
           if [[ "$DOCKER_IMAGE" == *"arm"* ]]; then sudo apt-get install -y -qq qemu-user-static git; fi
-          if [[ "$DOCKER_IMAGE" == *"arm64v8"* ]]; then export QEMU_VOLUME="-v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static"; fi #
+          if [[ "$DOCKER_IMAGE" == *"arm64v8"* ]]; then export QEMU_VOLUME="-v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static"; export PLATFORM_OPTION="--platform linux/aarch64"; fi #
           echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-          docker run --rm $QEMU_VOLUME -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "DOCKER_IMAGE=$DOCKER_IMAGE" -e "COLLISION_LIB=$COLLISION_LIB" -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"
+          docker run $PLATFORM_OPTION --rm $QEMU_VOLUME -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "DOCKER_IMAGE=$DOCKER_IMAGE" -e "COLLISION_LIB=$COLLISION_LIB" -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -t $DOCKER_IMAGE sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"
 
   catkin:
     runs-on: ubuntu-latest

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -23,7 +23,7 @@ jobs:
           - DOCKER_IMAGE: debian:stretch
           - DOCKER_IMAGE: osrf/ubuntu_armhf:trusty
           - DOCKER_IMAGE: osrf/ubuntu_armhf:xenial
-          - DOCKER_IMAGE: osrf/ubuntu_arm64:trusty
+          # - DOCKER_IMAGE: osrf/ubuntu_arm64:trusty  # deprecated
           - DOCKER_IMAGE: osrf/ubuntu_arm64:xenial
           - DOCKER_IMAGE: arm64v8/ubuntu:bionic
           - DOCKER_IMAGE: arm64v8/ubuntu:focal

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           ls -lar /__e/node20 &&
-          apt-get install -y curl &&
+          apt update && apt-get install -y curl &&
           curl -Lo /tmp/node.tar.gz https://unofficial-builds.nodejs.org/download/release/v20.17.0/node-v20.17.0-linux-x64-glibc-217.tar.gz &&
           cd /__e/node20 &&
           tar -x --strip-components=1 -f /tmp/node.tar.gz &&


### PR DESCRIPTION
commit eed159d35cd9216d88df962206409aabb5dc7aec

    .github/workflows/config.yml: use intel MacOS

commit 4bd5550715d3cebd87aea279d6ff24077bcc4d0e

    override node20 https://github.com/actions/upload-artifact/issues/616#issuecomment-2350667347

commit 959f9e6f05794caf0e694ddadd2627d16f59e6cf

    .github/workflows/config.yml: add --platform for qemu environment

    Fixes
    ```
    + docker run --rm --platform linux/amd64 -v /home/runner/work/EusLisp/EusLisp:/ws/euslisp -e ARCH=LinuxARM -t
arm32v7/debian:unstable-slim bash -c '      set -x; set -e;      apt update -qq;      apt install -y -qq make gcc
libgl-dev libglu1-mesa-dev libjpeg-dev libpng-dev libpq-dev libx11-dev libxext-dev;      CFLAGS='\''-Werror=implicit-function-declaration'\'' ARCH=LinuxARM EUSDIR=/ws/euslisp make -C /ws/euslisp/lisp/ -f Makefile.LinuxARM eus0;
     CC='\''gcc -Werror'\'' ARCHDIR=LinuxARM EUSDIR=/ws/euslisp make -C /ws/euslisp/lisp/image/jpeg;      exit 0'
    Unable to find image 'arm32v7/debian:unstable-slim' locally
    unstable-slim: Pulling from arm32v7/debian
    docker: no matching manifest for linux/amd64 in the manifest list entries.
    ```


commit 1dac047a8972ed198b223cef8bf3d483ab364cf5

    osrf/ubuntu_arm64:trusty is deprecated

    trusty: Pulling from osrf/ubuntu_arm64
    docker: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/osrf/ubuntu_arm64:trusty to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/.
