### PR TITLE
Support apple silicon arm architecture

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -228,6 +228,8 @@ jobs:
           export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
           # since macos-11, we need to install GL/gl.h
           HOMEBREW_NO_AUTO_UPDATE=1 brew install mesa-glu
+          # since macos-14, we need to install GL/gl.h for mesalib-glw and X11 for xquartz
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install mesalib-glw xquartz
           ./.travis-osx.sh
       - name: Cleanup some brew downloads
         run: cd ${{ steps.brew-cache.outputs.dir }} && ls -lsS | head -n 10 | awk '{ print $10 }' | xargs rm -rf

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -230,6 +230,8 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE=1 brew install mesa-glu
           # since macos-14, we need to install GL/gl.h for mesalib-glw and X11 for xquartz
           HOMEBREW_NO_AUTO_UPDATE=1 brew install mesalib-glw xquartz
+          # since macos-13, we need to install jpeg
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install jpeg
           ./.travis-osx.sh
       - name: Cleanup some brew downloads
         run: cd ${{ steps.brew-cache.outputs.dir }} && ls -lsS | head -n 10 | awk '{ print $10 }' | xargs rm -rf

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -112,7 +112,9 @@ jobs:
           apt-get install -qq -y dpkg  # necessary for catkin-pkg to be installable
           echo "Testing branch $GITHUB_REF of $GITHUB_REPOSITORY"
           sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
-          wget http://packages.ros.org/ros.key -O - | apt-key add -
+          # Replace the old apt-key add with the new method for adding the key
+          # https://github.com/ros/rosdistro/pull/46048
+          curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
           apt-get update -qq
           apt-get install -qq -y python-catkin-tools python-rosdep
           apt-get install -qq -y build-essential git ros-melodic-rosbash ros-melodic-rospack

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -206,7 +206,7 @@ jobs:
         id: brew-cache
         run: echo "::set-output name=dir::$(brew --cache)/downloads"
       - name: Brew cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.brew-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('.github/workflows/Brewfile') }}

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -186,7 +186,18 @@ jobs:
 
 
   osx:
-    runs-on: macos-13  # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
+    strategy:
+      matrix:
+        include:
+          # https://github.com/actions/runner-images/tree/main/images/macos
+          # Note: To test macOS-x with Intel architecture,
+          # you need to use the paid macOS-x-large runner, as macOS-x is grouped with ARM-based runners.
+          # https://docs.github.com/en/actions/concepts/runners/about-larger-runners
+          - runs-on: macos-13  # Intel (x64)
+          - runs-on: macos-14  # ARM64 (Apple Silicon)
+          - runs-on: macos-15  # ARM64 (Apple Silicon)
+      fail-fast: false
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/irteus/Makefile.Darwin
+++ b/irteus/Makefile.Darwin
@@ -53,7 +53,7 @@ ESFX=
 SOFLAGS=-g -falign-functions=8
 IMPLIB=-L$(EUSDIR)/$(ARCHDIR)/lib -leusgeo -L$(INSTALLLIBDIR) -lnr
 IMPLIBGL=-L$(EUSDIR)/$(ARCHDIR)/lib -leusgl -L/usr/X11R6/lib -lGLU -lGL -lXext
-IMPLIBIMG=-L/opt/local/lib/jpeg6b/lib -ljpeg -L/opt/local/lib -lpng
+IMPLIBIMG=-L/opt/local/lib/jpeg6b/lib -ljpeg -L/opt/local/lib -lpng -L/opt/homebrew/lib -L/usr/local/lib
 EXPLIB=
 RAPID=-LRAPID/$(ARCHDIR) -lRAPID-static
 RAPIDLIB=RAPID/$(ARCHDIR)/$(LPFX)RAPID-static.a
@@ -64,14 +64,23 @@ SVNVERSION=\"$(shell git rev-parse --short HEAD)\"
 ARCH=Darwin
 # copy from eus/lisp/Makefile.Darwin
 OS_VERSION=$(shell sw_vers -productVersion | sed s/\.[^.]*$$//)
+ARCH_TYPE=$(shell uname -m)
 ifeq ($(OS_VERSION), 10.5) 
  MACHINE=i386
 else
- MACHINE=x86_64
+ ifeq ($(ARCH_TYPE), arm64)
+  MACHINE=arm64
+ else
+  MACHINE=x86_64
+ endif
 endif
 THREAD= -DTHREADED -DPTHREAD
 
-CFLAGS=-O2 -D$(MACHINE) -D$(ARCH) -DLinux -D_REENTRANT -DGCC -I/opt/local/include -I$(EUSDIR)/include $(THREAD)  -DSVNVERSION=$(SVNVERSION)
+ifeq ($(MACHINE), arm64)
+CFLAGS=-O2 -D$(MACHINE) -Daarch64 -D$(ARCH) -DLinux -D_REENTRANT -DGCC -I/opt/local/include -I/opt/homebrew/include -I/usr/local/include -I$(EUSDIR)/include $(THREAD)  -DSVNVERSION=$(SVNVERSION)
+else
+CFLAGS=-O2 -D$(MACHINE) -D$(ARCH) -DLinux -D_REENTRANT -DGCC -I/opt/local/include -I/opt/homebrew/include -I/usr/local/include -I$(EUSDIR)/include $(THREAD)  -DSVNVERSION=$(SVNVERSION)
+endif
 CXXFLAGS=$(CFLAGS)
 
 CFLAGS+= -g -falign-functions=8 -fPIC

--- a/irteus/test/geo.l
+++ b/irteus/test/geo.l
@@ -11,7 +11,7 @@
          (normal (float-vector 0 0 0))
 	 eps)
     ;; somehow arm architecture needs to return #f(0 0 0) for small normalized vectors
-    (if (member :arm *features*)
+    (if (or (member :arm *features*) (member :aarch64 *features*))
 	(setq eps 1.0e-10)
       (setq eps 1.0e-20))
     (while vlist


### PR DESCRIPTION
# Build: Add Apple Silicon support for irteus
This commit updates the build system for the irteus module to enable native compilation on Apple Silicon (arm64) architecture.

The `irteus/Makefile.Darwin` is modified to:

- Automatically detect the arm64 architecture.
- Set the appropriate compiler flags (e.g., -Daarch64).
- Include the standard Homebrew library and header paths (/opt/homebrew/...) to find dependencies.

## quick start
```
make
source bashrc.eus
irteusgl irteus/demo/demo.l
(dual-arm-ik)
```

<img width="1341" alt="Screenshot 2025-06-26 at 22 25 25" src="https://github.com/user-attachments/assets/4893a318-ffaa-43a2-b1e3-ead8a85b7762" />

Related to https://github.com/euslisp/EusLisp/pull/529
