### PR TITLE
ci: Update macOS runner from deprecated macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -199,7 +199,11 @@ jobs:
           # Note: To test macOS-x with Intel architecture,
           # you need to use the paid macOS-x-large runner, as macOS-x is grouped with ARM-based runners.
           # https://docs.github.com/en/actions/concepts/runners/about-larger-runners
-          - runs-on: macos-13  # Intel (x64)
+          # Note: macos-13 is deprecated and will be retired by December 4, 2025
+          # Using macos-15-intel for Intel x86_64 architecture testing
+          # macos-latest (ARM-based Apple Silicon) for general testing
+          # https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
+          - runs-on: macos-15-intel  # Intel (x64)
           - runs-on: macos-14  # ARM64 (Apple Silicon)
           - runs-on: macos-15  # ARM64 (Apple Silicon)
       fail-fast: false


### PR DESCRIPTION
- Replace macos-13 with macos-15-intel for x86_64 testing
- Reference: GitHub Actions macos-13 retirement (Dec 4, 2025)

Reference: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/